### PR TITLE
Fix: truncate long bookmark titles so action buttons remain visible on hover

### DIFF
--- a/src/styles/NewTab.css
+++ b/src/styles/NewTab.css
@@ -53,9 +53,19 @@ body, html {
 
 a { margin-right: 5px; }
 
+/* Prevent long unbreakable titles from pushing action buttons off-screen */
+.bookmark-container a {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1 1 0;
+}
+
 /* Small “modify” icon button */
 .modify-link-button {
   @apply border-0 bg-transparent text-neutral-400 dark:text-neutral-400 ml-1 p-0;
+  flex-shrink: 0;
 }
 .modify-link-button:hover {
   @apply cursor-pointer text-neutral-200 dark:text-neutral-200;


### PR DESCRIPTION
When a bookmark title contained no spaces (e.g. a raw URL used as a name), the `<a>` element would grow beyond the card width and push the edit/copy/delete buttons off-screen, making them unreachable even on hover.

Fix: give `.bookmark-container` a `flex:1 1 0 / min-width:0 / overflow:hidden / text-overflow:ellipsis` rule so long titles truncate within the available space, and add `flex-shrink:0` to `.modify-link-button` so the action buttons are always rendered at their natural size next to the truncated title.