### PR TITLE
Bug Fixes

### DIFF
--- a/src/styles/NewTab.css
+++ b/src/styles/NewTab.css
@@ -43,7 +43,7 @@ body, html {
 .bookmark-group-box > *:hover { cursor: initial; }
 
 /* Per-item row */
-.bookmark-container { @apply flex items-center mb-1; }
+.bookmark-container { @apply flex items-start mb-1; }
 
 .favicon {
   @apply mr-1 align-middle inline-block h-5 w-5
@@ -56,9 +56,7 @@ a { margin-right: 5px; }
 /* Prevent long unbreakable titles from pushing action buttons off-screen */
 .bookmark-container a {
   min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  word-break: break-all;
   flex: 1 1 0;
 }
 


### PR DESCRIPTION
1. **Wrap long bookmark titles instead of truncating with ellipsis**. Titles with no spaces (e.g. raw URLs) now wrap to multiple lines using word-break: break-all, so the full title is always visible. Also changed `.bookmark-container` alignment from `items-center` to `items-start` so the favicon and action buttons anchor to the top of the row when text wraps.