### PR TITLE
Usability improvements

### DIFF
--- a/public/privacy/index.html
+++ b/public/privacy/index.html
@@ -49,7 +49,7 @@
 <body>
   <main>
     <h1>Privacy Policy for Mindful Bookmarks</h1>
-<p><strong>Effective date:</strong> 2026-03-28</p>
+<p><strong>Effective date:</strong> 2026-03-29</p>
 <p>Mindful Bookmarks (“Mindful,” “we,” “us”) gives you control over your data. You can use Mindful entirely <strong>offline</strong> in <em>Local-Only mode</em>, with no login and no data leaving your device, or optionally turn on <strong>Encrypted Sync</strong> to back up and sync your bookmarks securely across devices.</p>
 <hr>
 <h2>Storage Options</h2>
@@ -145,7 +145,7 @@ Email: <code>privacy@mindfulbookmarks.com</code></p>
 <hr>
 <h2>Changes to This Policy</h2>
 <p>We may update this Privacy Policy to reflect product or legal changes. The “Effective date” above will always show the latest version. If changes are material, we will provide notice within the app.</p>
-<p><em>Last updated: 2026-03-28</em></p>
+<p><em>Last updated: 2026-03-29</em></p>
 
   </main>
 </body>

--- a/public/privacy/index.html
+++ b/public/privacy/index.html
@@ -49,7 +49,7 @@
 <body>
   <main>
     <h1>Privacy Policy for Mindful Bookmarks</h1>
-<p><strong>Effective date:</strong> 2026-01-21</p>
+<p><strong>Effective date:</strong> 2026-03-28</p>
 <p>Mindful Bookmarks (“Mindful,” “we,” “us”) gives you control over your data. You can use Mindful entirely <strong>offline</strong> in <em>Local-Only mode</em>, with no login and no data leaving your device, or optionally turn on <strong>Encrypted Sync</strong> to back up and sync your bookmarks securely across devices.</p>
 <hr>
 <h2>Storage Options</h2>
@@ -145,7 +145,7 @@ Email: <code>privacy@mindfulbookmarks.com</code></p>
 <hr>
 <h2>Changes to This Policy</h2>
 <p>We may update this Privacy Policy to reflect product or legal changes. The “Effective date” above will always show the latest version. If changes are material, we will provide notice within the app.</p>
-<p><em>Last updated: 2026-01-21</em></p>
+<p><em>Last updated: 2026-03-28</em></p>
 
   </main>
 </body>

--- a/src/__tests__/components/AddBookmarkInline.test.tsx
+++ b/src/__tests__/components/AddBookmarkInline.test.tsx
@@ -61,14 +61,14 @@ describe('AddBookmarkInline Component', () => {
   test('should initially render the "Add a link" button', () => {
     renderComponent();
     expect(screen.getByText('+ Add a link')).toBeInTheDocument();
-    expect(screen.queryByPlaceholderText('Enter a link name')).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('Enter a link name (optional)')).not.toBeInTheDocument();
   });
 
   test('should show the new bookmark form when "Add a link" button is clicked', () => {
     renderComponent();
     fireEvent.click(screen.getByText('+ Add a link'));
 
-    expect(screen.getByPlaceholderText('Enter a link name')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Enter a link name (optional)')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('Enter a link URL')).toBeInTheDocument();
     expect(screen.getByText('Add link')).toBeInTheDocument();
   });
@@ -77,7 +77,7 @@ describe('AddBookmarkInline Component', () => {
     renderComponent();
     fireEvent.click(screen.getByText('+ Add a link'));
 
-    const nameInput = screen.getByPlaceholderText('Enter a link name') as HTMLInputElement;
+    const nameInput = screen.getByPlaceholderText('Enter a link name (optional)') as HTMLInputElement;
     const urlInput = screen.getByPlaceholderText('Enter a link URL') as HTMLInputElement;
 
     fireEvent.change(nameInput, { target: { value: 'Google' } });
@@ -91,7 +91,7 @@ describe('AddBookmarkInline Component', () => {
     renderComponent();
     fireEvent.click(screen.getByText('+ Add a link'));
 
-    fireEvent.change(screen.getByPlaceholderText('Enter a link name'), {
+    fireEvent.change(screen.getByPlaceholderText('Enter a link name (optional)'), {
       target: { value: 'Google' },
     });
     fireEvent.change(screen.getByPlaceholderText('Enter a link URL'), {
@@ -109,14 +109,14 @@ describe('AddBookmarkInline Component', () => {
       'https://www.google.com',
       'Test Group'
     );
-    expect(screen.queryByPlaceholderText('Enter a link name')).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('Enter a link name (optional)')).not.toBeInTheDocument();
   });
 
   test('should call handleSubmit when Enter key is pressed in the form', async () => {
     renderComponent();
     fireEvent.click(screen.getByText('+ Add a link'));
 
-    const nameInput = screen.getByPlaceholderText('Enter a link name');
+    const nameInput = screen.getByPlaceholderText('Enter a link name (optional)');
     const urlInput = screen.getByPlaceholderText('Enter a link URL');
 
     fireEvent.change(nameInput, { target: { value: 'Facebook' } });
@@ -137,11 +137,11 @@ describe('AddBookmarkInline Component', () => {
   test('should hide the form when the close button is clicked', () => {
     renderComponent();
     fireEvent.click(screen.getByText('+ Add a link'));
-    expect(screen.getByPlaceholderText('Enter a link name')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Enter a link name (optional)')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: /close form/i }));
 
-    expect(screen.queryByPlaceholderText('Enter a link name')).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('Enter a link name (optional)')).not.toBeInTheDocument();
     expect(screen.getByText('+ Add a link')).toBeInTheDocument();
   });
 });

--- a/src/__tests__/components/BookmarkGroup.test.jsx
+++ b/src/__tests__/components/BookmarkGroup.test.jsx
@@ -102,13 +102,15 @@ describe('BookmarkGroup', () => {
       },
     };
 
-    it('should hide the delete button and the add bookmark form', () => {
+    it('should still render the delete button and the add bookmark form', () => {
       render(<BookmarkGroup {...emptyGroupProps} />);
-      
-      // Use queryByRole for elements that should NOT exist.
-      expect(screen.queryByRole('button', { name: /delete group/i })).not.toBeInTheDocument();
-      expect(screen.queryByTestId('add-bookmark-inline')).not.toBeInTheDocument();
-      
+
+      // Delete button and add-link form now always render regardless of whether
+      // the group has a name (the headingIsEntered guard was removed to allow
+      // adding links inline before naming the group).
+      expect(screen.getByRole('button', { name: /delete group/i })).toBeInTheDocument();
+      expect(screen.getByTestId('add-bookmark-inline')).toBeInTheDocument();
+
       // Ensure the other parts still render correctly
       expect(screen.getByTestId('editable-heading')).toBeInTheDocument();
       expect(screen.getAllByTestId('editable-bookmark')).toHaveLength(1);

--- a/src/__tests__/components/CopyToModal.test.tsx
+++ b/src/__tests__/components/CopyToModal.test.tsx
@@ -1,15 +1,20 @@
 // src/__tests__/components/modals/CopyToModal.test.tsx
 
+jest.mock("@/scripts/AppContextProvider", () => ({
+  AppContext: require("react").createContext({ bumpWorkspacesVersion: jest.fn() }),
+}));
+
+jest.mock("@/scripts/workspaces/registry", () => ({
+  listLocalWorkspaces: jest.fn(),
+  createLocalWorkspace: jest.fn(),
+}));
+
 import React from "react";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import CopyToModal from "@/components/modals/CopyToModal"; 
+import CopyToModal from "@/components/modals/CopyToModal";
 import { listLocalWorkspaces } from "@/scripts/workspaces/registry";
-
-jest.mock("@/scripts/workspaces/registry", () => ({
-  listLocalWorkspaces: jest.fn(),
-}));
 
 const mockListLocalWorkspaces = listLocalWorkspaces as jest.MockedFunction<
   typeof listLocalWorkspaces

--- a/src/__tests__/components/EditableBookmark.test.jsx
+++ b/src/__tests__/components/EditableBookmark.test.jsx
@@ -3,25 +3,22 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
-import { EditableBookmark } from '@/components/EditableBookmark'; 
-import { AppContext } from '@/scripts/AppContextProvider'; 
-import { useBookmarkManager } from '@/hooks/useBookmarkManager'; 
+import { EditableBookmark } from '@/components/EditableBookmark';
+import { AppContext } from '@/scripts/AppContextProvider';
+import { useBookmarkManager } from '@/hooks/useBookmarkManager';
+import { constructValidURL } from '@/core/utils/url';
 
 // Mocks
 jest.mock('@/hooks/useBookmarkManager');
+jest.mock('@/core/utils/url');
 jest.mock('@/core/utils/ids', () => ({
   createUniqueID: jest.fn(() => 'unique-id-123'),
 }));
-const mockOpenCopyTo = jest.fn();
-jest.mock('@/scripts/events/copyToBridge', () => ({
-  openCopyTo: (...args) => mockOpenCopyTo(...args),
-}));
 
 describe('EditableBookmark Component', () => {
-  const mockEditBookmarkName = jest.fn();
+  const mockEditBookmark = jest.fn();
   const mockDeleteBookmark = jest.fn();
 
-  // Add an id for copy/move payload assertions
   const mockBookmark = { id: 'bookmark-1', name: 'Google', url: 'https://google.com' };
   const mockBookmarkGroups = [
     {
@@ -29,77 +26,110 @@ describe('EditableBookmark Component', () => {
       bookmarks: [mockBookmark, { id: 'bookmark-2', name: 'Bing', url: 'https://bing.com' }],
     },
   ];
-  const mockSetBookmarkGroups = jest.fn();
-  
-  // Reusable renderer with optional context overrides
+
   const renderComponent = (ctxOverrides = {}) => {
     useBookmarkManager.mockReturnValue({
       deleteBookmark: mockDeleteBookmark,
-      editBookmarkName: mockEditBookmarkName,
+      editBookmark: mockEditBookmark,
     });
 
     const contextValue = {
       bookmarkGroups: mockBookmarkGroups,
-      setBookmarkGroups: mockSetBookmarkGroups,
       userId: 'test-user-id',
-      activeWorkspaceId: 'ws-a', // default present for copy/move tests
       ...ctxOverrides,
     };
 
     return render(
       <AppContext.Provider value={contextValue}>
-        <EditableBookmark
-          bookmark={mockBookmark}
-          groupIndex={0}
-          bookmarkIndex={0}
-        />
+        <EditableBookmark bookmark={mockBookmark} groupIndex={0} bookmarkIndex={0} />
       </AppContext.Provider>
     );
   };
-  
+
+  const clipboardWriteText = jest.fn();
+
   beforeEach(() => {
     jest.clearAllMocks();
+    constructValidURL.mockImplementation((url) => url);
+    clipboardWriteText.mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: clipboardWriteText },
+      configurable: true,
+    });
   });
 
   // --- Rendering ---
-  test('should render the bookmark with correct name, link, and favicon', () => {
+  test('should render the bookmark with correct name and link', () => {
     renderComponent();
-
     const linkElement = screen.getByRole('link', { name: 'Google' });
     expect(linkElement).toBeInTheDocument();
     expect(linkElement).toHaveAttribute('href', 'https://google.com');
-
-    const faviconElement = document.querySelector('.favicon');
-    expect(faviconElement).toBeTruthy();
-    expect(faviconElement).toHaveAttribute('src', expect.stringContaining('google.com'));
-    expect(faviconElement.src).toMatch(
-      /icons\.duckduckgo\.com\/ip3\/google\.com\.ico|www\.google\.com\/s2\/favicons|t3\.gstatic\.com\/faviconV2/i
-    );
   });
-  
-  // --- Edit name flow ---
-  test('should allow editing the bookmark name on edit button click', async () => {
+
+  // --- Edit flow ---
+  test('edit button opens inline form pre-filled with current URL and name', async () => {
     const user = userEvent.setup();
     renderComponent();
-    
-    const linkElement = screen.getByRole('link', { name: 'Google' });
-    const editButton = screen.getByRole('button', { name: /edit bookmark/i });
 
-    await user.click(editButton);
+    await user.click(screen.getByRole('button', { name: /edit bookmark/i }));
 
-    expect(linkElement).toHaveAttribute('contenteditable', 'true');
-    
-    linkElement.focus();
-    await user.clear(linkElement);
-    await user.type(linkElement, 'Google Search');
-    fireEvent.keyDown(linkElement, { key: 'Enter', code: 'Enter' });
-    
+    expect(screen.getByPlaceholderText('Enter a link URL')).toHaveValue('https://google.com');
+    expect(screen.getByPlaceholderText('Enter a link name (optional)')).toHaveValue('Google');
+  });
+
+  test('submitting the edit form calls editBookmark with new values', async () => {
+    const user = userEvent.setup();
+    renderComponent();
+
+    await user.click(screen.getByRole('button', { name: /edit bookmark/i }));
+
+    const nameInput = screen.getByPlaceholderText('Enter a link name (optional)');
+    await user.clear(nameInput);
+    await user.type(nameInput, 'Google Search');
+
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
     await waitFor(() => {
-      expect(mockEditBookmarkName).toHaveBeenCalledWith(0, 0, 'Google Search');
+      expect(mockEditBookmark).toHaveBeenCalledWith(0, 0, 'Google Search', 'https://google.com');
     });
+    expect(screen.queryByPlaceholderText('Enter a link URL')).not.toBeInTheDocument();
+  });
 
-    expect(linkElement).not.toHaveAttribute('contenteditable', 'true');
-    expect(screen.getByRole('link', { name: 'Google Search' })).toBeInTheDocument();
+  test('pressing Enter in the edit form submits it', async () => {
+    const user = userEvent.setup();
+    renderComponent();
+
+    await user.click(screen.getByRole('button', { name: /edit bookmark/i }));
+
+    const urlInput = screen.getByPlaceholderText('Enter a link URL');
+    fireEvent.keyDown(urlInput.closest('form'), { key: 'Enter', code: 'Enter' });
+
+    await waitFor(() => {
+      expect(mockEditBookmark).toHaveBeenCalledWith(0, 0, 'Google', 'https://google.com');
+    });
+  });
+
+  test('pressing Escape cancels the edit without saving', async () => {
+    const user = userEvent.setup();
+    renderComponent();
+
+    await user.click(screen.getByRole('button', { name: /edit bookmark/i }));
+    expect(screen.getByPlaceholderText('Enter a link URL')).toBeInTheDocument();
+
+    const urlInput = screen.getByPlaceholderText('Enter a link URL');
+    fireEvent.keyDown(urlInput.closest('form'), { key: 'Escape', code: 'Escape' });
+
+    expect(screen.queryByPlaceholderText('Enter a link URL')).not.toBeInTheDocument();
+    expect(mockEditBookmark).not.toHaveBeenCalled();
+  });
+
+  // --- Copy flow ---
+  test('copy button writes the bookmark URL to clipboard', async () => {
+    renderComponent();
+
+    fireEvent.click(screen.getByRole('button', { name: /copy link url/i }));
+
+    expect(clipboardWriteText).toHaveBeenCalledWith('https://google.com');
   });
 
   // --- Delete flow ---
@@ -108,54 +138,24 @@ describe('EditableBookmark Component', () => {
     const user = userEvent.setup();
     renderComponent();
 
-    const deleteButton = screen.getByRole('button', { name: /delete bookmark/i });
-    await user.click(deleteButton);
-    
+    await user.click(screen.getByRole('button', { name: /delete bookmark/i }));
+
     expect(window.confirm).toHaveBeenCalledWith(
       'Are you sure you want to delete the "Google" bookmark from "Search Engines"?'
     );
-
     await waitFor(() => {
       expect(mockDeleteBookmark).toHaveBeenCalledWith(0, 0);
     });
   });
-  
+
   test('should not call deleteBookmark when deletion is cancelled', async () => {
     jest.spyOn(window, 'confirm').mockImplementation(() => false);
-
     const user = userEvent.setup();
     renderComponent();
 
-    const deleteButton = screen.getByRole('button', { name: /delete bookmark/i });
-    await user.click(deleteButton);
+    await user.click(screen.getByRole('button', { name: /delete bookmark/i }));
 
     expect(window.confirm).toHaveBeenCalled();
     expect(mockDeleteBookmark).not.toHaveBeenCalled();
-  });
-
-  // --- Copy / Move flow ---
-  test('clicking Copy/Move opens the copy modal bridge with correct payload when activeWorkspaceId exists', async () => {
-    const user = userEvent.setup();
-    renderComponent(); // activeWorkspaceId defaults to 'ws-a'
-
-    const copyBtn = screen.getByRole('button', { name: /copy\/move bookmark/i });
-    await user.click(copyBtn);
-
-    expect(mockOpenCopyTo).toHaveBeenCalledTimes(1);
-    expect(mockOpenCopyTo).toHaveBeenCalledWith({
-      kind: 'bookmark',
-      fromWorkspaceId: 'ws-a',
-      bookmarkIds: ['bookmark-1'],
-    });
-  });
-
-  test('clicking Copy/Move does nothing when activeWorkspaceId is missing', async () => {
-    const user = userEvent.setup();
-    renderComponent({ activeWorkspaceId: undefined });
-
-    const copyBtn = screen.getByRole('button', { name: /copy\/move bookmark/i });
-    await user.click(copyBtn);
-
-    expect(mockOpenCopyTo).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/components/modals/CopyToModal.test.tsx
+++ b/src/__tests__/components/modals/CopyToModal.test.tsx
@@ -1,14 +1,22 @@
-import React from "react";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import CopyToModal from "@/components/modals/CopyToModal";
-import { listLocalWorkspaces } from "@/scripts/workspaces/registry";
+jest.mock("@/scripts/AppContextProvider", () => ({
+  AppContext: require("react").createContext({ bumpWorkspacesVersion: jest.fn() }),
+}));
 
 jest.mock("@/scripts/workspaces/registry", () => ({
   listLocalWorkspaces: jest.fn(),
+  createLocalWorkspace: jest.fn(),
 }));
+
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import CopyToModal from "@/components/modals/CopyToModal";
+import { listLocalWorkspaces, createLocalWorkspace } from "@/scripts/workspaces/registry";
 
 const listLocalWorkspacesMock = listLocalWorkspaces as jest.MockedFunction<
   typeof listLocalWorkspaces
+>;
+const createLocalWorkspaceMock = createLocalWorkspace as jest.MockedFunction<
+  typeof createLocalWorkspace
 >;
 
 type Ws = { id: any; name: string };
@@ -81,9 +89,9 @@ describe("CopyToModal", () => {
 
     const select = screen.getByLabelText(/destination workspace/i) as HTMLSelectElement;
 
-    // Filtered out w1, leaving w2/w3
+    // Filtered out w1, leaving w2/w3 + "New workspace" option
     await waitFor(() => {
-      expect(select.options).toHaveLength(2);
+      expect(select.options).toHaveLength(3);
       expect(select.options[0].value).toBe("w2");
       expect(select.options[1].value).toBe("w3");
     });
@@ -133,7 +141,7 @@ describe("CopyToModal", () => {
     expect(onClose).toHaveBeenCalledTimes(4);
   });
 
-  it("disables Confirm when there are no destination workspaces (dest is null)", async () => {
+  it("enables Confirm when only the current workspace exists, pre-selecting + New workspace", async () => {
     setup({
       open: true,
       currentWorkspaceId: "w1",
@@ -142,8 +150,11 @@ describe("CopyToModal", () => {
 
     await screen.findByRole("dialog");
 
+    const select = screen.getByLabelText(/destination workspace/i) as HTMLSelectElement;
+    expect(select.value).toBe("__new__");
+
     const confirmBtn = screen.getByRole("button", { name: /confirm/i });
-    expect(confirmBtn).toBeDisabled();
+    expect(confirmBtn).toBeEnabled();
   });
 
   it("calls onConfirm with default destination and move=false when Confirm is clicked", async () => {
@@ -188,7 +199,15 @@ describe("CopyToModal", () => {
     expect(onConfirm).toHaveBeenCalledWith("w2", true);
   }); 
 
-  it("does not confirm on Enter if no destination exists", async () => {
+  it("creates a new workspace and confirms on Enter when + New workspace is pre-selected", async () => {
+    createLocalWorkspaceMock.mockResolvedValueOnce({
+      id: "ws-new",
+      name: "New Workspace",
+      storageMode: "local",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    } as any);
+
     const { onConfirm } = setup({
       open: true,
       currentWorkspaceId: "w1",
@@ -198,7 +217,11 @@ describe("CopyToModal", () => {
     await screen.findByRole("dialog");
 
     fireEvent.keyDown(document, { key: "Enter" });
-    expect(onConfirm).not.toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect(createLocalWorkspaceMock).toHaveBeenCalledWith("New Workspace", { setActive: false });
+      expect(onConfirm).toHaveBeenCalledWith("ws-new", false);
+    });
   });
 
   it("uses the default title when not provided, and custom title when provided", async () => {

--- a/src/components/AddBookmarkInline.tsx
+++ b/src/components/AddBookmarkInline.tsx
@@ -338,29 +338,27 @@ function CreateNewBookmark({
   /* -------------------- Sub component UI -------------------- */
   return (
     <div className="create-new-bookmark-component">
-      <div className="form-container">
-        <form onKeyDown={handleKeyDown}>
-          <input
-            type="text"
-            placeholder="Enter a link URL"
-            value={bookmarkUrl}
-            onChange={handleBookmarkUrlChange}
-            pattern={URL_PATTERN}
-            required
-            aria-label="Link URL"
-            ref={focusField === 'url' ? setMergedRef : urlInputRef}
-          />
-          <input
-            type="text"
-            placeholder="Enter a link name (optional)"
-            value={bookmarkName}
-            onChange={handleBookmarkNameChange}
-            aria-label="Link Name"
-            ref={focusField === 'name' ? setMergedRef : nameInputRef}
-          />
-        </form>
-      </div>
-      <div className="flex items-center gap-2">
+      <form onKeyDown={handleKeyDown}>
+        <input
+          type="text"
+          placeholder="Enter a link URL"
+          value={bookmarkUrl}
+          onChange={handleBookmarkUrlChange}
+          pattern={URL_PATTERN}
+          required
+          aria-label="Link URL"
+          ref={focusField === 'url' ? setMergedRef : urlInputRef}
+        />
+        <input
+          type="text"
+          placeholder="Enter a link name (optional)"
+          value={bookmarkName}
+          onChange={handleBookmarkNameChange}
+          aria-label="Link Name"
+          ref={focusField === 'name' ? setMergedRef : nameInputRef}
+        />
+      </form>
+      <div className="form-actions">
         <button
           type="submit"
           className="add-bookmark-button-2"

--- a/src/components/AddBookmarkInline.tsx
+++ b/src/components/AddBookmarkInline.tsx
@@ -162,7 +162,7 @@ function CreateNewBookmark({
   setLinkBeingEdited,
   autoFocus = false,
   inputRef,
-  focusField = 'name',
+  focusField = 'url',
   onDone,
   prefillUrl,
   prefillName,
@@ -238,8 +238,9 @@ function CreateNewBookmark({
   async function handleSubmit(e: React.SyntheticEvent) {
     e.preventDefault();
     const urlWithProtocol = constructValidURL(bookmarkUrl);
+    const finalName = bookmarkName.trim() || deriveNameFromUrl(urlWithProtocol) || urlWithProtocol;
     capture("bookmark_added", { surface: "newtab" });
-    await addNamedBookmark(bookmarkName, urlWithProtocol, groupName);
+    await addNamedBookmark(finalName, urlWithProtocol, groupName);
 
     // Find this group's id (prefer hydrated, fallback to index)
     const candidates = (bookmarkGroups?.length ? bookmarkGroups : groupsIndex) || [];
@@ -341,15 +342,6 @@ function CreateNewBookmark({
         <form onKeyDown={handleKeyDown}>
           <input
             type="text"
-            placeholder="Enter a link name"
-            value={bookmarkName}
-            onChange={handleBookmarkNameChange}
-            required
-            aria-label="Link Name"
-            ref={focusField === 'name' ? setMergedRef : nameInputRef}
-          />
-          <input
-            type="text"
             placeholder="Enter a link URL"
             value={bookmarkUrl}
             onChange={handleBookmarkUrlChange}
@@ -357,6 +349,14 @@ function CreateNewBookmark({
             required
             aria-label="Link URL"
             ref={focusField === 'url' ? setMergedRef : urlInputRef}
+          />
+          <input
+            type="text"
+            placeholder="Enter a link name (optional)"
+            value={bookmarkName}
+            onChange={handleBookmarkNameChange}
+            aria-label="Link Name"
+            ref={focusField === 'name' ? setMergedRef : nameInputRef}
           />
         </form>
       </div>
@@ -396,7 +396,7 @@ export function AddBookmarkInline(props: AddBookmarkInlineProps) {
     groupIndex,
     autoFocus = false,     // open + focus automatically
     inputRef,              // exposes the main input element to parent (Grid)
-    focusField = 'name',    // 'url' | 'name'
+    focusField = 'url',    // 'url' | 'name'
     onDone,                // called after submit/close
     // NEW: optional explicit prefills (take precedence over clipboard)
     prefillUrl,

--- a/src/components/BookmarkGroup.tsx
+++ b/src/components/BookmarkGroup.tsx
@@ -132,40 +132,38 @@ export const BookmarkGroup: React.FC<BookmarkGroupProps> = ({
     >
       {/* Actions (Delete + Copy/Move) */}
       {/* Only show the actions when the BookmarkGroup is hovered over */}
-      {headingIsEntered && (
-        <div
-          className="
-            absolute right-2 top-2 flex items-center 
-            text-neutral-400 dark:text-neutral-400
+      <div
+        className="
+          absolute right-2 top-2 flex items-center
+          text-neutral-400 dark:text-neutral-400
 
-            opacity-0 pointer-events-none
-            transition-opacity duration-150
+          opacity-0 pointer-events-none
+          transition-opacity duration-150
 
-            group-hover:opacity-100 group-hover:pointer-events-auto
-            focus-within:opacity-100 focus-within:pointer-events-auto
-          "
+          group-hover:opacity-100 group-hover:pointer-events-auto
+          focus-within:opacity-100 focus-within:pointer-events-auto
+        "
+      >
+        <button
+          className="icon-button p-1 hover:text-neutral-500 dark:hover:text-neutral-300 transition-colors cursor-pointer"
+          onClick={onCopyGroup}
+          onPointerDown={(e) => e.stopPropagation()}
+          aria-label="Copy/Move group"
+          title="Copy/Move group"
         >
-          <button
-            className="icon-button p-1 hover:text-neutral-500 dark:hover:text-neutral-300 transition-colors cursor-pointer"
-            onClick={onCopyGroup}
-            onPointerDown={(e) => e.stopPropagation()}
-            aria-label="Copy/Move group"
-            title="Copy/Move group"
-          >
-            <i className="far fa-copy text-sm" />
-          </button>
+          <i className="far fa-copy text-sm" />
+        </button>
 
-          <button
-            className="icon-button p-1 hover:text-rose-600 dark:hover:text-rose-400 transition-colors cursor-pointer"
-            onClick={(event) => handleDeleteBookmarkGroup(event, groupIndex)}
-            onPointerDown={(e) => e.stopPropagation()}
-            aria-label="Delete group"
-            title="Delete group"
-          >
-            <i className="fas fa-xmark text-sm" />
-          </button>
-        </div>
-      )}
+        <button
+          className="icon-button p-1 hover:text-rose-600 dark:hover:text-rose-400 transition-colors cursor-pointer"
+          onClick={(event) => handleDeleteBookmarkGroup(event, groupIndex)}
+          onPointerDown={(e) => e.stopPropagation()}
+          aria-label="Delete group"
+          title="Delete group"
+        >
+          <i className="fas fa-xmark text-sm" />
+        </button>
+      </div>
 
       {/* Header */}
       <div onPointerDown={stopPropagation} className="bookmark-group-header">
@@ -189,21 +187,19 @@ export const BookmarkGroup: React.FC<BookmarkGroupProps> = ({
           ))}
         </SortableContext>
 
-        {/* Inline add link: shown only when the group has a real title */}
-        {headingIsEntered && (
-          <AddBookmarkInline
-            groupIndex={groupIndex}
-            autoFocus={autoAddLink}
-            inputRef={addLinkInputRef}
-            onDone={onAddLinkDone}
+        {/* Inline add link */}
+        <AddBookmarkInline
+          groupIndex={groupIndex}
+          autoFocus={autoAddLink}
+          inputRef={addLinkInputRef}
+          onDone={onAddLinkDone}
 
-            /* Only during onboarding: pass constant prefills
-               (explicit prefills take precedence over clipboard inside the component) */
-            prefillName={autofillFromClipboard ? ONBOARDING_BOOKMARK_NAME_PREFILL : undefined}
-            prefillUrl={autofillFromClipboard ? ONBOARDING_BOOKMARK_URL_PREFILL : undefined}
-            autofillFromClipboard={autofillFromClipboard}
-          />
-        )}
+          /* Only during onboarding: pass constant prefills
+             (explicit prefills take precedence over clipboard inside the component) */
+          prefillName={autofillFromClipboard ? ONBOARDING_BOOKMARK_NAME_PREFILL : undefined}
+          prefillUrl={autofillFromClipboard ? ONBOARDING_BOOKMARK_URL_PREFILL : undefined}
+          autofillFromClipboard={autofillFromClipboard}
+        />
       </div>
     </div>
   );

--- a/src/components/DraggableGrid.tsx
+++ b/src/components/DraggableGrid.tsx
@@ -306,7 +306,7 @@ const DraggableGrid = forwardRef<GridHandle, DraggableGridProps>(function Dragga
       // insert-before vs insert-after by comparing the dragged item's vertical
       // center to the over item's center. This ensures dropping below the last
       // item in a group appends it rather than landing above that item.
-      if (!overIsGroupContainer && active.rect.current.translated && over.rect) {
+      if (!overIsGroupContainer && active.rect?.current?.translated && over.rect) {
         const draggedCenterY =
           active.rect.current.translated.top + active.rect.current.translated.height / 2;
         const overCenterY = over.rect.top + over.rect.height / 2;

--- a/src/components/DraggableGrid.tsx
+++ b/src/components/DraggableGrid.tsx
@@ -4,7 +4,7 @@ import React, {
 } from "react";
 import {
   DndContext,
-  closestCorners,
+  closestCenter,
   useSensor,
   useSensors,
   PointerSensor,
@@ -302,6 +302,18 @@ const DraggableGrid = forwardRef<GridHandle, DraggableGridProps>(function Dragga
     if (source.groupIndex === destination.groupIndex) {
       reorderBookmarks(source.bookmarkIndex, destination.bookmarkIndex, source.groupIndex);
     } else {
+      // When dropping onto a specific bookmark (not a group container), decide
+      // insert-before vs insert-after by comparing the dragged item's vertical
+      // center to the over item's center. This ensures dropping below the last
+      // item in a group appends it rather than landing above that item.
+      if (!overIsGroupContainer && active.rect.current.translated && over.rect) {
+        const draggedCenterY =
+          active.rect.current.translated.top + active.rect.current.translated.height / 2;
+        const overCenterY = over.rect.top + over.rect.height / 2;
+        if (draggedCenterY > overCenterY) {
+          destination.bookmarkIndex += 1;
+        }
+      }
       moveBookmark(source, destination);
     }
   }
@@ -332,7 +344,7 @@ const DraggableGrid = forwardRef<GridHandle, DraggableGridProps>(function Dragga
   return (
     <DndContext
       sensors={sensors}
-      collisionDetection={closestCorners}
+      collisionDetection={closestCenter}
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
       onDragCancel={() => setActiveItem(null)}

--- a/src/components/EditableBookmark.tsx
+++ b/src/components/EditableBookmark.tsx
@@ -1,11 +1,12 @@
 /* -------------------- Imports -------------------- */
-import React, { useState, useRef, useContext, useCallback } from 'react';
+import React, { useState, useRef, useContext, useCallback, useEffect } from 'react';
 
 import type { BookmarkType } from "@/core/types/bookmarks";
 import type { AppContextValue } from "@/scripts/AppContextProvider";
 
 /* CSS styles */
 import '@/styles/NewTab.css';
+import '@/styles/AddBookmarkInline.css';
 
 /* Hooks */
 import { useBookmarkManager } from '@/hooks/useBookmarkManager';
@@ -18,6 +19,9 @@ import { openCopyTo } from '@/scripts/events/copyToBridge';
 
 /* Components */
 import SmartFavicon from '@/components/SmartFavicon';
+
+/* Utilities */
+import { constructValidURL } from "@/core/utils/url";
 /* ---------------------------------------------------------- */
 
 /* -------------------- Local types -------------------- */
@@ -33,76 +37,78 @@ export function EditableBookmark({ bookmark, groupIndex, bookmarkIndex }: Editab
   /* -------------------- Context / state -------------------- */
   const { bookmarkGroups, activeWorkspaceId } = useContext(AppContext) as AppContextValue;
 
-  // Get all actions from the custom bookmarks hook
-  const { 
+  const {
     deleteBookmark,
-    editBookmarkName, 
-  } = useBookmarkManager();  
+    editBookmark,
+  } = useBookmarkManager();
 
   const [text, setText] = useState<string>(bookmark.name ?? '');
-  const [url] = useState<string>(bookmark.url ?? '');       
+  const [url, setUrl] = useState<string>(bookmark.url ?? '');
 
-  const aRef = useRef<HTMLAnchorElement>(null);
+  const [isEditing, setIsEditing] = useState(false);
+  const [editUrl, setEditUrl] = useState('');
+  const [editName, setEditName] = useState('');
+
+  const editUrlRef = useRef<HTMLInputElement>(null);
+  /* ---------------------------------------------------------- */
+
+  /* -------------------- Effects -------------------- */
+  /**
+   * Focus the URL field whenever the edit form opens.
+   */
+  useEffect(() => {
+    if (isEditing) {
+      const t = setTimeout(() => {
+        editUrlRef.current?.focus();
+        editUrlRef.current?.select();
+      }, 0);
+      return () => clearTimeout(t);
+    }
+  }, [isEditing]);
   /* ---------------------------------------------------------- */
 
   /* -------------------- Helper functions -------------------- */
   /**
-   * Enter inline edit mode for a bookmark title and persist the change on blur/Enter.
+   * Open the inline edit form pre-filled with the current bookmark values.
    */
-  const handleBookmarkNameEdit = useCallback((
-    _event: React.MouseEvent<HTMLButtonElement>,
-    grpIndex: number,
-    bmIndex: number
-  ) => {
-    const aElement = aRef.current;
-    if (!aElement) return; 
-    if (aElement.isContentEditable) return;  // prevent double-initialization
+  const handleEditClick = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    setEditUrl(url);
+    setEditName(text);
+    setIsEditing(true);
+  }, [url, text]);
 
-    // Make the <a> element's content editable
-    aElement.setAttribute('contenteditable', 'true');
-    aElement.focus();
+  /**
+   * Persist the edited name and URL, then close the form.
+   */
+  const handleEditSubmit = useCallback(async (e: React.SyntheticEvent) => {
+    e.preventDefault();
+    const urlWithProtocol = constructValidURL(editUrl);
+    const finalName = editName.trim() || urlWithProtocol;
+    setText(finalName);
+    setUrl(urlWithProtocol);
+    setIsEditing(false);
+    await editBookmark(groupIndex, bookmarkIndex, finalName, urlWithProtocol);
+  }, [editUrl, editName, groupIndex, bookmarkIndex, editBookmark]);
 
-    // Select all text in the <a> element
-    const selection = typeof window !== 'undefined' ? window.getSelection() : null; 
-    if (selection) {
-      const range = document.createRange();
-      range.selectNodeContents(aElement);
-      selection.removeAllRanges();
-      selection.addRange(range);
+  /**
+   * Close the edit form without saving.
+   */
+  const handleEditCancel = useCallback(() => {
+    setIsEditing(false);
+  }, []);
+
+  /**
+   * Treat Enter as submit and Escape as cancel inside the edit form.
+   */
+  function handleEditKeyDown(e: React.KeyboardEvent<HTMLFormElement>) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleEditSubmit(e);
+    } else if (e.key === 'Escape') {
+      handleEditCancel();
     }
-
-    // Use native events; type them precisely
-    const onKeyDown = (ev: KeyboardEvent) => {
-      if (ev.key === 'Enter') {
-        ev.preventDefault();
-        aElement.blur(); // triggers blur handler
-      } else if (ev.key === 'Escape') {                      
-        aElement.textContent = text;
-        aElement.blur();
-      }
-    };
-
-    const cleanup = () => {                                   
-      aElement.setAttribute('contenteditable', 'false');
-      aElement.removeEventListener('keydown', onKeyDown);
-      aElement.removeEventListener('blur', onBlur);
-    };
-
-    const onBlur = async (ev: FocusEvent) => {
-      // target is EventTarget | null; narrow to HTMLAnchorElement
-      const target = ev.target as HTMLAnchorElement | null;
-      const newBookmarkName = target?.textContent?.trim() ?? '';
-
-      if (newBookmarkName !== text) {  // avoid no-op writes
-        setText(newBookmarkName);
-        await editBookmarkName(grpIndex, bmIndex, newBookmarkName);
-      }
-      cleanup(); 
-    };
-
-    aElement.addEventListener('keydown', onKeyDown);
-    aElement.addEventListener('blur', onBlur, { once: true });
-  }, [editBookmarkName, text]); 
+  }
 
   /**
    * Confirm and remove a bookmark from its group.
@@ -114,11 +120,11 @@ export function EditableBookmark({ bookmark, groupIndex, bookmarkIndex }: Editab
   ) => {
     const bookmarkGroup = bookmarkGroups[groupIndex];
     if (!bookmarkGroup) return;
-    const bookmark = bookmarkGroup.bookmarks[bookmarkIndex];
-    if (!bookmark) return;
-    
+    const bm = bookmarkGroup.bookmarks[bookmarkIndex];
+    if (!bm) return;
+
     const shouldDelete = window.confirm(
-      `Are you sure you want to delete the "${bookmark.name}" bookmark from "${bookmarkGroup.groupName}"?`
+      `Are you sure you want to delete the "${bm.name}" bookmark from "${bookmarkGroup.groupName}"?`
     );
     if (shouldDelete) {
       await deleteBookmark(bmIndex, grpIndex);
@@ -128,32 +134,75 @@ export function EditableBookmark({ bookmark, groupIndex, bookmarkIndex }: Editab
   /**
    * Trigger the copy-to modal for a single bookmark within the active workspace.
    */
-  const handleBookmarkCopy = useCallback((event: React.MouseEvent<HTMLButtonElement>) => { 
-    event.stopPropagation(); // don’t start a drag
+  const handleBookmarkCopy = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
     if (!activeWorkspaceId) return;
     openCopyTo({
       kind: 'bookmark',
       fromWorkspaceId: activeWorkspaceId,
-      bookmarkIds: [bookmark.id], // single-bookmark copy; we can extend to multiselect later
+      bookmarkIds: [bookmark.id],
     });
   }, [activeWorkspaceId, bookmark.id]);
   /* ---------------------------------------------------------- */
 
   /* -------------------- Component UI -------------------- */
+  if (isEditing) {
+    return (
+      <div className="create-new-bookmark-component">
+        <div className="form-container">
+          <form onKeyDown={handleEditKeyDown}>
+            <input
+              type="text"
+              placeholder="Enter a link URL"
+              value={editUrl}
+              onChange={e => setEditUrl(e.target.value)}
+              required
+              aria-label="Link URL"
+              ref={editUrlRef}
+            />
+            <input
+              type="text"
+              placeholder="Enter a link name (optional)"
+              value={editName}
+              onChange={e => setEditName(e.target.value)}
+              aria-label="Link Name"
+            />
+          </form>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="submit"
+            className="add-bookmark-button-2"
+            onClick={handleEditSubmit}
+            aria-label="Save"
+          >
+            Save
+          </button>
+          <button
+            className="close-form-button"
+            onClick={handleEditCancel}
+            aria-label="Cancel edit"
+          >
+            <i className="fas fa-xmark text-sm" />
+          </button>
+        </div>
+      </div>
+    );
+  }
+
   return (
-    <div className="bookmark-container">                      
+    <div className="bookmark-container">
       <SmartFavicon
         url={url}
         size={20}
         className="favicon"
         fallback="letter"
       />
-      
+
       <a
         href={url}
         target="_blank"
         rel="noopener noreferrer"
-        ref={aRef}
         className="text-base"
       >
         {text}
@@ -161,19 +210,18 @@ export function EditableBookmark({ bookmark, groupIndex, bookmarkIndex }: Editab
 
       <button
         type="button"
-        className='modify-link-button' 
-        // preventDefault avoids focus ripple in some browsers
-        onClick={(event) => { event.preventDefault(); handleBookmarkNameEdit(event, groupIndex, bookmarkIndex); }}
+        className='modify-link-button'
+        onClick={handleEditClick}
         aria-label="Edit bookmark"
         title="Edit bookmark"
       >
         <i className="fa fa-pencil text-xsm" />
       </button>
-      <button 
+      <button
         type="button"
-        className='modify-link-button' 
+        className='modify-link-button'
         onClick={handleBookmarkCopy}
-        disabled={!activeWorkspaceId}  // explicit disabled state
+        disabled={!activeWorkspaceId}
         aria-label="Copy/Move bookmark"
         title="Copy/Move bookmark"
       >
@@ -181,8 +229,8 @@ export function EditableBookmark({ bookmark, groupIndex, bookmarkIndex }: Editab
       </button>
       <button
         type="button"
-        className='modify-link-button' 
-        onClick={(event) => handleBookmarkDelete(event, groupIndex, bookmarkIndex)}  
+        className='modify-link-button'
+        onClick={(event) => handleBookmarkDelete(event, groupIndex, bookmarkIndex)}
         aria-label="Delete bookmark"
         title="Delete bookmark"
       >

--- a/src/components/EditableBookmark.tsx
+++ b/src/components/EditableBookmark.tsx
@@ -14,9 +14,6 @@ import { useBookmarkManager } from '@/hooks/useBookmarkManager';
 /* Scripts */
 import { AppContext } from '@/scripts/AppContextProvider';
 
-/* Events */
-import { openCopyTo } from '@/scripts/events/copyToBridge';
-
 /* Components */
 import SmartFavicon from '@/components/SmartFavicon';
 
@@ -35,7 +32,7 @@ type EditableBookmarkProps = {
 /* -------------------- Main component -------------------- */
 export function EditableBookmark({ bookmark, groupIndex, bookmarkIndex }: EditableBookmarkProps) {
   /* -------------------- Context / state -------------------- */
-  const { bookmarkGroups, activeWorkspaceId } = useContext(AppContext) as AppContextValue;
+  const { bookmarkGroups } = useContext(AppContext) as AppContextValue;
 
   const {
     deleteBookmark,
@@ -132,17 +129,12 @@ export function EditableBookmark({ bookmark, groupIndex, bookmarkIndex }: Editab
   }, [bookmarkGroups, groupIndex, bookmarkIndex, deleteBookmark]);
 
   /**
-   * Trigger the copy-to modal for a single bookmark within the active workspace.
+   * Copy the bookmark URL to the clipboard.
    */
   const handleBookmarkCopy = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
-    if (!activeWorkspaceId) return;
-    openCopyTo({
-      kind: 'bookmark',
-      fromWorkspaceId: activeWorkspaceId,
-      bookmarkIds: [bookmark.id],
-    });
-  }, [activeWorkspaceId, bookmark.id]);
+    navigator.clipboard.writeText(url);
+  }, [url]);
   /* ---------------------------------------------------------- */
 
   /* -------------------- Component UI -------------------- */
@@ -219,9 +211,8 @@ export function EditableBookmark({ bookmark, groupIndex, bookmarkIndex }: Editab
         type="button"
         className='modify-link-button'
         onClick={handleBookmarkCopy}
-        disabled={!activeWorkspaceId}
-        aria-label="Copy/Move bookmark"
-        title="Copy/Move bookmark"
+        aria-label="Copy link URL"
+        title="Copy link URL"
       >
         <i className="far fa-copy text-xs" />
       </button>

--- a/src/components/EditableBookmark.tsx
+++ b/src/components/EditableBookmark.tsx
@@ -149,27 +149,25 @@ export function EditableBookmark({ bookmark, groupIndex, bookmarkIndex }: Editab
   if (isEditing) {
     return (
       <div className="create-new-bookmark-component">
-        <div className="form-container">
-          <form onKeyDown={handleEditKeyDown}>
-            <input
-              type="text"
-              placeholder="Enter a link URL"
-              value={editUrl}
-              onChange={e => setEditUrl(e.target.value)}
-              required
-              aria-label="Link URL"
-              ref={editUrlRef}
-            />
-            <input
-              type="text"
-              placeholder="Enter a link name (optional)"
-              value={editName}
-              onChange={e => setEditName(e.target.value)}
-              aria-label="Link Name"
-            />
-          </form>
-        </div>
-        <div className="flex items-center gap-2">
+        <form onKeyDown={handleEditKeyDown}>
+          <input
+            type="text"
+            placeholder="Enter a link URL"
+            value={editUrl}
+            onChange={e => setEditUrl(e.target.value)}
+            required
+            aria-label="Link URL"
+            ref={editUrlRef}
+          />
+          <input
+            type="text"
+            placeholder="Enter a link name (optional)"
+            value={editName}
+            onChange={e => setEditName(e.target.value)}
+            aria-label="Link Name"
+          />
+        </form>
+        <div className="form-actions">
           <button
             type="submit"
             className="add-bookmark-button-2"

--- a/src/components/EditableBookmark.tsx
+++ b/src/components/EditableBookmark.tsx
@@ -45,6 +45,7 @@ export function EditableBookmark({ bookmark, groupIndex, bookmarkIndex }: Editab
   const [isEditing, setIsEditing] = useState(false);
   const [editUrl, setEditUrl] = useState('');
   const [editName, setEditName] = useState('');
+  const [copied, setCopied] = useState(false);
 
   const editUrlRef = useRef<HTMLInputElement>(null);
   /* ---------------------------------------------------------- */
@@ -134,6 +135,8 @@ export function EditableBookmark({ bookmark, groupIndex, bookmarkIndex }: Editab
   const handleBookmarkCopy = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
     navigator.clipboard.writeText(url);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
   }, [url]);
   /* ---------------------------------------------------------- */
 
@@ -211,10 +214,10 @@ export function EditableBookmark({ bookmark, groupIndex, bookmarkIndex }: Editab
         type="button"
         className='modify-link-button'
         onClick={handleBookmarkCopy}
-        aria-label="Copy link URL"
-        title="Copy link URL"
+        aria-label={copied ? "Copied!" : "Copy link URL"}
+        title={copied ? "Copied!" : "Copy link URL"}
       >
-        <i className="far fa-copy text-xs" />
+        <i className={copied ? "fas fa-check text-xs" : "far fa-copy text-xs"} />
       </button>
       <button
         type="button"

--- a/src/components/modals/CopyToModal.tsx
+++ b/src/components/modals/CopyToModal.tsx
@@ -1,18 +1,23 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useContext, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import type { WorkspaceIdType } from "@/core/constants/workspaces";
-import { listLocalWorkspaces } from "@/scripts/workspaces/registry";
+import { listLocalWorkspaces, createLocalWorkspace } from "@/scripts/workspaces/registry";
+import { AppContext } from "@/scripts/AppContextProvider";
+
+const NEW_WS = "__new__";
 
 type Props = {
   open: boolean;
   onClose: () => void;
   onConfirm: (destWorkspaceId: WorkspaceIdType, move: boolean) => void;
   currentWorkspaceId: WorkspaceIdType;
-  title?: string; 
+  title?: string;
 };
 
 /**
  * Modal that lets users pick another workspace to copy/move bookmark payloads into.
+ * When no other workspaces exist, or when the user selects "+ New workspace", a name
+ * input is shown and the workspace is created on confirm.
  *
  * @param props Component props.
  * @param props.open Whether the modal is currently displayed.
@@ -32,12 +37,21 @@ export default function CopyToModal({
     useState<Array<{ id: WorkspaceIdType; name: string }>>([]);
   const [dest, setDest] = useState<WorkspaceIdType | null>(null);
   const [move, setMove] = useState(false);
+  const [newName, setNewName] = useState("New Workspace");
+  const [creating, setCreating] = useState(false);
+
+  const { bumpWorkspacesVersion } = useContext(AppContext) as { bumpWorkspacesVersion: () => void };
 
   const panelRef = useRef<HTMLDivElement | null>(null);
   const selectRef = useRef<HTMLSelectElement | null>(null);
+  const newNameRef = useRef<HTMLInputElement | null>(null);
+
+  const isCreatingNew = dest === NEW_WS;
+  const canConfirm = !!dest && !creating;
 
   /**
    * Fetch workspace choices every time the modal opens so the list stays fresh.
+   * Pre-select "+ New workspace" when no other workspaces are available.
    */
   useEffect(() => {
     if (!open) return;
@@ -45,35 +59,61 @@ export default function CopyToModal({
       const all = await listLocalWorkspaces();
       const filtered = all.filter((w) => w.id !== currentWorkspaceId);
       setWorkspaces(filtered);
-      setDest(filtered[0]?.id ?? null);
+      setDest(filtered[0]?.id ?? NEW_WS);
       setMove(false);
+      setNewName("New Workspace");
     })();
   }, [open, currentWorkspaceId]);
 
   /**
-   * Listen for Escape/Enter key presses while the modal is open to support quick dismissal/confirm.
+   * Focus the new-workspace name input when it appears, otherwise focus the select.
+   */
+  useEffect(() => {
+    if (!open) return;
+    queueMicrotask(() => {
+      if (isCreatingNew) {
+        newNameRef.current?.focus();
+        newNameRef.current?.select();
+      } else {
+        selectRef.current?.focus();
+      }
+    });
+  }, [open, isCreatingNew]);
+
+  /**
+   * Create the destination workspace (if needed) then invoke onConfirm.
+   */
+  async function handleConfirm() {
+    if (!dest) return;
+    if (isCreatingNew) {
+      setCreating(true);
+      try {
+        const ws = await createLocalWorkspace(newName.trim() || "New Workspace", { setActive: false });
+        bumpWorkspacesVersion();
+        onConfirm(ws.id, move);
+      } finally {
+        setCreating(false);
+      }
+    } else {
+      onConfirm(dest, move);
+    }
+  }
+
+  /**
+   * Listen for Escape/Enter key presses while the modal is open.
    */
   useEffect(() => {
     if (!open) return;
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose?.();
-      if (e.key === "Enter" && dest) {
+      if (e.key === "Enter" && canConfirm) {
         e.preventDefault();
-        onConfirm(dest, move);
+        handleConfirm();
       }
     };
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
-  }, [open, dest, move, onClose, onConfirm]);
-
-  /**
-   * Focus the destination select input as soon as the modal becomes visible.
-   */
-  useEffect(() => {
-    if (open) {
-      queueMicrotask(() => selectRef.current?.focus());
-    }
-  }, [open]);
+  }, [open, canConfirm, handleConfirm, onClose]);
 
   if (!open) return null;
 
@@ -143,9 +183,7 @@ export default function CopyToModal({
                     id="copyto-dest"
                     ref={selectRef}
                     value={dest ?? ""}
-                    onChange={(e) =>
-                      setDest(e.target.value as WorkspaceIdType)
-                    }
+                    onChange={(e) => setDest(e.target.value as WorkspaceIdType)}
                     className="block w-full appearance-none rounded-xl border border-neutral-300 bg-white px-3 py-2.5 text-sm
                                text-neutral-900 shadow-sm transition
                                hover:border-neutral-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20
@@ -157,6 +195,7 @@ export default function CopyToModal({
                         {w.name}
                       </option>
                     ))}
+                    <option value={NEW_WS}>+ New workspace</option>
                   </select>
 
                   {/* chevron */}
@@ -175,9 +214,25 @@ export default function CopyToModal({
                     </svg>
                   </div>
                 </div>
+
+                {/* New workspace name input */}
+                {isCreatingNew && (
+                  <input
+                    ref={newNameRef}
+                    type="text"
+                    value={newName}
+                    onChange={(e) => setNewName(e.target.value)}
+                    placeholder="Workspace name"
+                    aria-label="New workspace name"
+                    className="mt-2 block w-full rounded-xl border border-neutral-300 bg-white px-3 py-2.5 text-sm
+                               text-neutral-900 shadow-sm transition placeholder:text-neutral-400
+                               hover:border-neutral-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20
+                               dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:border-neutral-600
+                               dark:focus:border-blue-500 dark:placeholder:text-neutral-500"
+                  />
+                )}
               </div>
 
-              
               <div className="rounded-xl border border-neutral-200 p-3 transition hover:border-neutral-300 dark:border-neutral-800">
                 <label className="inline-flex items-center text-sm text-neutral-800 dark:text-neutral-200">
                   <input
@@ -201,19 +256,19 @@ export default function CopyToModal({
                        hover:bg-neutral-50 dark:hover:bg-neutral-800
                        border-neutral-300 dark:border-neutral-700
                        text-neutral-800 dark:text-neutral-100
-                         shadow-sm transition 
+                         shadow-sm transition
                          focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/70"
             >
               Cancel
             </button>
             <button
-              onClick={() => dest && onConfirm(dest, move)}
-              disabled={!dest}
+              onClick={handleConfirm}
+              disabled={!canConfirm}
               className="inline-flex cursor-pointer items-center justify-center rounded-xl bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm
                          transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60
                          focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/70"
             >
-              Confirm
+              {creating ? "Creating…" : "Confirm"}
             </button>
           </div>
         </div>

--- a/src/hooks/useBookmarkManager.ts
+++ b/src/hooks/useBookmarkManager.ts
@@ -31,6 +31,7 @@ interface BookmarkManager {
   addNamedBookmark: (bookmarkName: string, url: string, groupName: string) => Promise<void>;
   deleteBookmark: (bookmarkIndex: number, groupIndex: number) => Promise<void>;
   editBookmarkName: (groupIndex: number, bookmarkIndex: number, newBookmarkName: string) => Promise<void>;
+  editBookmark: (groupIndex: number, bookmarkIndex: number, newName: string, newUrl: string) => Promise<void>;
   reorderBookmarks: (oldBookmarkIndex: number, newBookmarkIndex: number, groupIndex: number) => Promise<void>;
   moveBookmark: (source: BookmarkMoveLocation, destination: BookmarkMoveLocation) => Promise<void>;
   exportBookmarksToJSON: () => void;
@@ -321,6 +322,33 @@ export const useBookmarkManager = (): BookmarkManager => {
   };
 
   /**
+   * Update both the display name and URL for an existing bookmark.
+   *
+   * @param groupIndex Index of the parent group.
+   * @param bookmarkIndex Index of the bookmark within that group.
+   * @param newName New bookmark name to set.
+   * @param newUrl New bookmark URL to set.
+   * @returns Promise resolving once the bookmark is updated.
+   */
+  const editBookmark = async (
+    groupIndex: number,
+    bookmarkIndex: number,
+    newName: string,
+    newUrl: string
+  ): Promise<void> => {
+    await updateAndPersistGroups(prevGroups => {
+      const updatedGroups = cloneGroups(prevGroups);
+      if (updatedGroups[groupIndex]?.bookmarks[bookmarkIndex]) {
+        updatedGroups[groupIndex].bookmarks[bookmarkIndex].name = newName;
+        updatedGroups[groupIndex].bookmarks[bookmarkIndex].url = newUrl;
+      } else {
+        console.error("Error: Tried to edit a bookmark that doesn't exist.", { groupIndex, bookmarkIndex });
+      }
+      return updatedGroups;
+    });
+  };
+
+  /**
    * Append a new bookmark to the specified group, creating the group if necessary.
    *
    * @param bookmarkName Display name for the bookmark.
@@ -458,6 +486,7 @@ export const useBookmarkManager = (): BookmarkManager => {
     addNamedBookmark,
     deleteBookmark,
     editBookmarkName,
+    editBookmark,
     reorderBookmarks,
     moveBookmark,
     exportBookmarksToJSON,

--- a/src/styles/AddBookmarkInline.css
+++ b/src/styles/AddBookmarkInline.css
@@ -1,6 +1,6 @@
-@reference "@/styles/Index.css"; /* so utilities are available here */
-/*@import "./NewTab.css";*/
+@reference "@/styles/Index.css";
 
+/* ---- "+ Add a link" trigger ---- */
 .add-link-inline-container { @apply relative; }
 
 .bookmark-group-box .add-bookmark-button-1 {
@@ -9,55 +9,64 @@
          focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/60;
 }
 .dark .bookmark-group-box .add-bookmark-button-1 {
-  @apply bg-neutral-900 text-neutral-400 hover:bg-neutral-800 hover:text-neutral-200;
+  @apply bg-neutral-900 text-neutral-500 hover:bg-neutral-800 hover:text-neutral-300;
 }
 
-.create-new-bookmark-component { @apply relative rounded-lg p-2.5 bg-neutral-100; }
-.dark .create-new-bookmark-component { @apply bg-neutral-800; }
-
-.create-new-bookmark-component { @apply relative rounded-lg p-2.5 bg-neutral-100; }
-.dark .create-new-bookmark-component { @apply bg-neutral-800; }
-
-.form-container {
-  @apply static mb-2.5 rounded-md p-2.5 border shadow
+/* ---- Form card ---- */
+.create-new-bookmark-component {
+  @apply rounded-lg overflow-hidden border shadow-sm
          bg-white border-neutral-200;
 }
-.dark .form-container { @apply bg-neutral-900 border-neutral-700; }
+.dark .create-new-bookmark-component {
+  @apply bg-neutral-900 border-neutral-700;
+}
 
-form { @apply flex flex-col gap-1.5 w-full min-w-[200px] box-border rounded-lg; }
+/* ---- Inputs ---- */
+/* Scoped to the component to avoid overriding other inputs on the page */
+.create-new-bookmark-component form {
+  @apply flex flex-col gap-0 w-full;
+}
 
-input[type="text"] {
-  @apply w-full text-sm py-1.5 px-0 mb-0 border-0 rounded-none shadow-none
-         bg-white text-neutral-900 placeholder:text-neutral-400
+.create-new-bookmark-component input[type="text"] {
+  @apply w-full text-sm py-2.5 px-3 border-0 border-b border-neutral-200
+         bg-transparent text-neutral-900 placeholder:text-neutral-400
          focus:outline-none focus:ring-0;
 }
-.dark input[type="text"] {
-  @apply bg-neutral-900;          
-  @apply text-neutral-100 placeholder:text-neutral-400;
+.dark .create-new-bookmark-component input[type="text"] {
+  @apply text-neutral-100 placeholder:text-neutral-500 border-neutral-700;
 }
 
-/* If we also have textareas, include them too */
-.dark textarea {
-  @apply bg-black text-neutral-100 placeholder:text-neutral-400
-          ring-1 ring-white/10 focus:ring-2 focus:ring-white/20;
+/* Last input has no bottom border — the action row separator takes over */
+.create-new-bookmark-component input[type="text"]:last-of-type {
+  @apply border-b-0;
 }
 
-/* Optional: tame Chrome autofill yellow in dark mode */
-.dark input[type="text"]:-webkit-autofill {
+/* Chrome autofill tint fix in dark mode */
+.dark .create-new-bookmark-component input[type="text"]:-webkit-autofill {
   -webkit-text-fill-color: #e5e5e5;
-  -webkit-box-shadow: 0 0 0 1000px #000 inset;
+  -webkit-box-shadow: 0 0 0 1000px #171717 inset;
   caret-color: #e5e5e5;
 }
 
-.add-bookmark-button-2 {
-  @apply cursor-pointer flex-1 rounded-2xl px-4 py-2 font-semibold transition
-       bg-blue-600 hover:bg-blue-500 text-white;
+/* ---- Action row ---- */
+.form-actions {
+  @apply flex items-center gap-2 px-3 py-2
+         border-t border-neutral-200;
+}
+.dark .form-actions {
+  @apply border-neutral-700;
 }
 
+/* ---- Submit button ---- */
+.add-bookmark-button-2 {
+  @apply cursor-pointer flex-1 rounded-md px-3 py-1.5 text-sm font-semibold transition
+         bg-blue-600 hover:bg-blue-500 text-white;
+}
+
+/* ---- Cancel button ---- */
 .close-form-button {
-  @apply border-0 bg-transparent text-neutral-400 dark:text-neutral-400 ml-1 p-2;
+  @apply border-0 bg-transparent text-neutral-400 dark:text-neutral-500 p-1.5 rounded
+         hover:text-neutral-600 dark:hover:text-neutral-300
+         hover:bg-neutral-100 dark:hover:bg-neutral-800
+         transition-colors;
 }
-.close-form-button:hover {
-  @apply cursor-pointer text-neutral-200 dark:text-neutral-200;
-}
-.close-form-button-img { width: 16px; height: 16px; }

--- a/src/styles/AddBookmarkInline.css
+++ b/src/styles/AddBookmarkInline.css
@@ -28,12 +28,13 @@
 }
 
 .create-new-bookmark-component input[type="text"] {
-  @apply w-full text-sm py-2.5 px-3 border-0 border-b border-neutral-200
-         bg-transparent text-neutral-900 placeholder:text-neutral-400
+  @apply w-full text-sm py-2 px-3 mb-0 border-0 border-b border-neutral-200
+         rounded-none shadow-none bg-transparent
+         text-neutral-900 placeholder:text-neutral-400
          focus:outline-none focus:ring-0;
 }
 .dark .create-new-bookmark-component input[type="text"] {
-  @apply text-neutral-100 placeholder:text-neutral-500 border-neutral-700;
+  @apply bg-transparent text-neutral-100 placeholder:text-neutral-500 border-neutral-700;
 }
 
 /* Last input has no bottom border — the action row separator takes over */
@@ -68,5 +69,5 @@
   @apply border-0 bg-transparent text-neutral-400 dark:text-neutral-500 p-1.5 rounded
          hover:text-neutral-600 dark:hover:text-neutral-300
          hover:bg-neutral-100 dark:hover:bg-neutral-800
-         transition-colors;
+         hover:cursor-pointer transition-colors;
 }


### PR DESCRIPTION
## Summary

- **Allow links to be added inline before the group has a name** — removed the `headingIsEntered` guard from `AddBookmarkInline` and the group action buttons
- **Make bookmark title optional** — auto-derives a display name from the URL when left blank; name field is second and clearly marked optional
- **Swap input order** — URL comes first (since title is now optional); default focus goes to the URL field
- **Edit button opens the same form as adding a link** — replaces the old contenteditable title-only edit with a pre-filled URL + name inline form that saves both fields via a new `editBookmark` hook action
- **Copy button copies the link URL to clipboard** — replaces the copy/move workspace modal with a direct `navigator.clipboard.writeText` call; icon swaps to a checkmark for 1.5s as confirmation then reverts
- **CSS cleanup** — scoped all form/input rules to `.create-new-bookmark-component` to fix a font-size regression caused by conflicting global rules; replaced the double-container design with a single clean card; fixed input padding, spacing, and dark-mode background bleed-through; added `cursor-pointer` on the close button
- **Create a new workspace from the copy UI** — adds a `+ New workspace` option to the destination dropdown in the copy/move modal; when selected, a name input appears and the workspace is created on confirm without switching the active workspace; the workspace pane refreshes immediately via `bumpWorkspacesVersion`; `+ New workspace` is pre-selected when no other workspaces exist so the Confirm button is never disabled
- **Fix drag-and-drop ordering for cross-group drops** — when dropping a bookmark into another group, the item now lands before or after the hovered bookmark based on which half of it the dragged center falls on, rather than always inserting before it; fixes the case where dropping below the last item placed the bookmark above it instead of after it. Also switches collision detection from `closestCorners` to `closestCenter`, which is the correct algorithm for vertical sortable lists and prevents false matches to neighbouring group cards

## Test plan

- [x] Add a link to a group that has no name yet — the inline form should appear
<img width="279" height="267" alt="image" src="https://github.com/user-attachments/assets/fefef71a-cd68-4cbf-98e6-b56523d67fe9" />

- [x] Submit with only a URL — bookmark should auto-derive a name from the URL
<img src="https://github.com/user-attachments/assets/a0d0fac9-e26f-43c6-99ec-9a4591252346" width="300">

- [x] Submit with both URL and name — the provided name should be used as-is
<img src="https://github.com/user-attachments/assets/51edea11-8eb6-4505-8674-ab2fef50d710" width="300">

- [x] Verify the URL field is focused by default when the inline form opens
<img src="https://github.com/user-attachments/assets/798617ca-37ae-4e94-a520-700ebc5e284a" width="300">

- [x] Click the edit (pencil) button on an existing bookmark — form should open pre-filled with the current URL and name
- [x] Edit the URL only, submit — URL and auto-derived name should update
- [x] Edit both URL and name, submit — both should update
- [x] Press Escape while editing — changes should be discarded
- [x] Click the copy button on a bookmark — the link URL should be written to the clipboard; icon should briefly show a checkmark then revert to the copy icon
- [x] Verify group delete/copy buttons appear on hover regardless of whether the group has a title
- [x] Check light and dark mode — no extra spacing between inputs, no dark background bleed on inputs, close button shows pointer cursor on hover
- [x] Open the copy/move modal with only one workspace — `+ New workspace` should be pre-selected and the Confirm button should be enabled
<img width="567" height="373" alt="image" src="https://github.com/user-attachments/assets/13110c7d-124a-441c-bd50-13f1e236eda8" />

- [x] Open the copy/move modal with multiple workspaces — existing workspaces should appear first, with `+ New workspace` as the last option
<img width="570" height="323" alt="image" src="https://github.com/user-attachments/assets/ef7d5ec4-10c7-41f3-a692-038bbce835be" />

- [x] Select `+ New workspace`, edit the name, and confirm — a new workspace should be created with that name and the copy should proceed
- [x] After creating a workspace via the copy modal, verify it appears immediately in the workspace pane without a page reload
- [x] Drag a bookmark from one group and drop it below the last item in another group — it should appear after the last item, not above it
- [x] Drag a bookmark from one group and drop it onto the top half of an item in another group — it should appear before that item
- [x] Drag a bookmark from one group and drop it onto the bottom half of an item in another group — it should appear after that item
- [x] Drag a bookmark within its own group — ordering should still work correctly in both directions

🤖 Generated with [Claude Code](https://claude.com/claude-code)