### PR TITLE
feat: drag-and-drop JSON/HTML file import on the main page

### DIFF
--- a/src/__tests__/pages/NewTabPage.test.tsx
+++ b/src/__tests__/pages/NewTabPage.test.tsx
@@ -15,10 +15,40 @@ import * as useBookmarkManager from '@/hooks/useBookmarkManager';
 import useImportBookmarksDefault from '@/hooks/useImportBookmarks';
 import * as ChromeUtils from '@/core/utils/chrome';
 import * as StorageKeysUtils from '@/core/utils/storageKeys';
-import { StorageMode, type StorageModeType } from '@/core/constants/storageMode'; 
+import { StorageMode, type StorageModeType } from '@/core/constants/storageMode';
+import { commitManualImportIntoWorkspace } from '@/scripts/import/commitManualImportIntoWorkspace';
+import { createWorkspaceServiceLocal } from '@/scripts/import/workspaceServiceLocal';
+/* ---------------------------------------------------------- */
+
+/* -------------------- Drag-and-drop test helpers -------------------- */
+/**
+ * Returns stable jest.fn() instances stored on globalThis so they survive
+ * jest.mock() hoisting and remain accessible inside mock factories.
+ */
+function getDragTestMocks() {
+  const g = globalThis as any;
+  if (!g.__newTabDragMocks__) {
+    g.__newTabDragMocks__ = {
+      bumpPostImport: jest.fn(),
+      bumpWorkspacesVersion: jest.fn(),
+    };
+  }
+  return g.__newTabDragMocks__ as {
+    bumpPostImport: jest.Mock;
+    bumpWorkspacesVersion: jest.Mock;
+  };
+}
 /* ---------------------------------------------------------- */
 
 /* -------------------- Mocks -------------------- */
+
+jest.mock('@/scripts/import/workspaceServiceLocal', () => ({
+  createWorkspaceServiceLocal: jest.fn(() => ({})),
+}));
+
+jest.mock('@/scripts/import/commitManualImportIntoWorkspace', () => ({
+  commitManualImportIntoWorkspace: jest.fn(),
+}));
 const useImportBookmarksMock =
   useImportBookmarksDefault as unknown as jest.MockedFunction<typeof useImportBookmarksDefault>;
 
@@ -90,6 +120,7 @@ jest.mock('@/scripts/AppContextProvider', () => {
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
+    const dragMocks = getDragTestMocks();
     const value: Ctx = {
       bookmarkGroups,
       setBookmarkGroups,
@@ -102,6 +133,9 @@ jest.mock('@/scripts/AppContextProvider', () => {
       isSignedIn,
       hasHydrated,
       isHydratingRemote: false,
+      workspaces: {},
+      bumpPostImport: dragMocks.bumpPostImport,
+      bumpWorkspacesVersion: dragMocks.bumpWorkspacesVersion,
     };
 
     return <AppContext.Provider value={value}>{children}</AppContext.Provider>;
@@ -479,5 +513,212 @@ describe.each([
 
     fireEvent.click(screen.getByText('Sign Out'));
     expect(mockSignOut).toHaveBeenCalledTimes(1);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* NewTabPage – file drag-and-drop                                      */
+/* ------------------------------------------------------------------ */
+
+describe('NewTabPage file drag-and-drop', () => {
+  const { bumpPostImport, bumpWorkspacesVersion } = getDragTestMocks();
+  const mockCommit = commitManualImportIntoWorkspace as jest.Mock;
+  const mockCreateService = createWorkspaceServiceLocal as jest.Mock;
+  const fakeService = { __service: 'fake' };
+
+  /* Helpers */
+
+  /** Dispatch a dragenter event on window, optionally carrying files. */
+  function fireDragEnter(withFiles = true) {
+    act(() => {
+      window.dispatchEvent(
+        Object.assign(new Event('dragenter', { cancelable: true }), {
+          dataTransfer: { types: withFiles ? ['Files'] : [] },
+        })
+      );
+    });
+  }
+
+  /** Dispatch a dragleave event on window. */
+  function fireDragLeave() {
+    act(() => window.dispatchEvent(new Event('dragleave')));
+  }
+
+  /** Dispatch a drop event carrying the given file. */
+  function fireDrop(file: File) {
+    act(() => {
+      window.dispatchEvent(
+        Object.assign(new Event('drop', { cancelable: true }), {
+          dataTransfer: { types: ['Files'], files: [file] },
+        })
+      );
+    });
+  }
+
+  /** Create a File and patch .text() since jsdom doesn't implement Blob.text(). */
+  function makeFile(name: string, content: string, type: string) {
+    const file = new File([content], name, { type });
+    (file as any).text = () => Promise.resolve(content);
+    return file;
+  }
+
+  function makeJsonFile(name = 'bookmarks.json', content = '{"tabs":[]}') {
+    return makeFile(name, content, 'application/json');
+  }
+
+  /** Render the page and wait until fully hydrated (Toast is in the ready subtree). */
+  async function renderPage() {
+    (globalThis as any).__TEST_STORAGE_MODE__ = StorageMode.LOCAL;
+    render(
+      <AppContextProvider user={null}>
+        <NewTabPage />
+      </AppContextProvider>
+    );
+    await screen.findByTestId('top-banner');
+    await screen.findByTestId('draggable-grid');
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    bumpPostImport.mockClear();
+    bumpWorkspacesVersion.mockClear();
+    mockCreateService.mockReturnValue(fakeService);
+    mockCommit.mockResolvedValue(undefined);
+    (globalThis as any).__TEST_STORAGE_MODE__ = StorageMode.LOCAL;
+    bookmarksDataMock.loadInitialBookmarks.mockResolvedValue(mockBookmarkGroups);
+    (useBookmarkManagerMock.useBookmarkManager as jest.Mock).mockReturnValue({
+      addEmptyBookmarkGroup: jest.fn(),
+      exportBookmarksToJSON: jest.fn(),
+      importBookmarksFromJSON: jest.fn(),
+      changeStorageMode: jest.fn(),
+    });
+    useImportBookmarksMock.mockReturnValue({
+      openImport: jest.fn(),
+      closeImport: jest.fn(),
+      renderModal: jest.fn(() => <div />),
+      busy: false,
+      handleUploadJson: jest.fn(),
+      handleImportChrome: jest.fn(),
+      handleImportOpenTabs: jest.fn(),
+    } as any);
+  });
+
+  afterEach(() => cleanup());
+
+  /* -- Overlay visibility -- */
+
+  test('shows drop overlay when a file is dragged over the page', async () => {
+    await renderPage();
+    fireDragEnter(true);
+    expect(screen.getByText('Drop to import bookmarks')).toBeInTheDocument();
+    expect(screen.getByText('.json or .html files supported')).toBeInTheDocument();
+  });
+
+  test('does not show drop overlay for non-file drags (e.g. dragging text)', async () => {
+    await renderPage();
+    fireDragEnter(false);
+    expect(screen.queryByText('Drop to import bookmarks')).not.toBeInTheDocument();
+  });
+
+  test('hides overlay when drag leaves the page', async () => {
+    await renderPage();
+    fireDragEnter(true);
+    expect(screen.getByText('Drop to import bookmarks')).toBeInTheDocument();
+    fireDragLeave();
+    expect(screen.queryByText('Drop to import bookmarks')).not.toBeInTheDocument();
+  });
+
+  test('keeps overlay visible across nested dragenter events, hides only when counter reaches zero', async () => {
+    await renderPage();
+    fireDragEnter(true);
+    fireDragEnter(true); // enter a nested element
+    fireDragLeave();     // leave the nested element – still dragging over page
+    expect(screen.getByText('Drop to import bookmarks')).toBeInTheDocument();
+    fireDragLeave();     // leave the page entirely
+    expect(screen.queryByText('Drop to import bookmarks')).not.toBeInTheDocument();
+  });
+
+  test('hides overlay on drop', async () => {
+    await renderPage();
+    fireDragEnter(true);
+    expect(screen.getByText('Drop to import bookmarks')).toBeInTheDocument();
+    fireDrop(makeJsonFile());
+    expect(screen.queryByText('Drop to import bookmarks')).not.toBeInTheDocument();
+  });
+
+  /* -- Import logic -- */
+
+  test('calls commitManualImportIntoWorkspace with correct args when a JSON file is dropped', async () => {
+    await renderPage();
+    fireDrop(makeJsonFile('my-bookmarks.json', '{"groups":[]}'));
+
+    await waitFor(() => expect(mockCommit).toHaveBeenCalledTimes(1));
+    expect(mockCommit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selection: {
+          jsonData: '{"groups":[]}',
+          jsonFileName: 'my-bookmarks.json',
+          workspaceName: 'my-bookmarks',
+        },
+        purposes: [],
+        purpose: 'personal',
+        workspaceService: fakeService,
+      })
+    );
+  });
+
+  test('accepts .html files and strips extension for workspace name', async () => {
+    await renderPage();
+    fireDrop(makeFile('chrome-export.html', '<html></html>', 'text/html'));
+
+    await waitFor(() => expect(mockCommit).toHaveBeenCalledTimes(1));
+    expect(mockCommit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selection: expect.objectContaining({
+          jsonFileName: 'chrome-export.html',
+          workspaceName: 'chrome-export',
+        }),
+      })
+    );
+  });
+
+  test('shows success toast and bumps workspace version after successful drop', async () => {
+    await renderPage();
+    fireDrop(makeJsonFile());
+
+    expect(await screen.findByText('Bookmarks imported successfully!')).toBeInTheDocument();
+    expect(bumpWorkspacesVersion).toHaveBeenCalledTimes(1);
+  });
+
+  test('calls bumpPostImport with the previous workspace IDs after a 150 ms delay', async () => {
+    jest.useFakeTimers();
+    try {
+      await renderPage();
+      fireDrop(makeJsonFile());
+
+      await waitFor(() => expect(bumpWorkspacesVersion).toHaveBeenCalledTimes(1));
+      expect(bumpPostImport).not.toHaveBeenCalled();
+
+      act(() => jest.advanceTimersByTime(150));
+      expect(bumpPostImport).toHaveBeenCalledWith([]); // workspaces:{} → previousIds=[]
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test('shows error toast for unsupported file type', async () => {
+    await renderPage();
+    fireDrop(makeFile('notes.txt', 'data', 'text/plain'));
+
+    expect(await screen.findByText('Please drop a .json or .html bookmarks file.')).toBeInTheDocument();
+    expect(mockCommit).not.toHaveBeenCalled();
+  });
+
+  test('shows error toast when the import throws', async () => {
+    mockCommit.mockRejectedValueOnce(new Error('Parse failed'));
+    await renderPage();
+    fireDrop(makeJsonFile());
+
+    expect(await screen.findByText('Import failed: Parse failed')).toBeInTheDocument();
   });
 });

--- a/src/pages/NewTabPage.tsx
+++ b/src/pages/NewTabPage.tsx
@@ -28,6 +28,8 @@ import { getUserStorageKey } from '@/core/utils/storageKeys';
 import { loadInitialBookmarks } from '@/scripts/bookmarksData';
 import { AppContext } from "@/scripts/AppContextProvider";
 import { copyItems, moveItems } from "@/scripts/copyBookmarks";
+import { commitManualImportIntoWorkspace } from '@/scripts/import/commitManualImportIntoWorkspace';
+import { createWorkspaceServiceLocal } from '@/scripts/import/workspaceServiceLocal';
 
 /* Components */
 import TopBanner from "@/components/TopBanner";
@@ -54,6 +56,9 @@ type AppCtxShape = {
   isSignedIn: boolean;
   hasHydrated: boolean;
   isHydratingRemote: boolean;
+  workspaces: Record<string, any>;
+  bumpPostImport: (previousIds: string[]) => void;
+  bumpWorkspacesVersion: () => void;
 };
 
 type NewTabPageProps = {
@@ -103,6 +108,9 @@ export function NewTabPage({ user, signIn, signOut }: NewTabPageProps): ReactEle
     isSignedIn,
     hasHydrated,
     isHydratingRemote,
+    workspaces,
+    bumpPostImport,
+    bumpWorkspacesVersion,
   } = useContext(AppContext) as AppCtxShape;
 
   const gridRef = useRef<GridHandle | null>(null);
@@ -126,6 +134,10 @@ export function NewTabPage({ user, signIn, signOut }: NewTabPageProps): ReactEle
   const pendingCopyRef = useRef<CopyPayload | null>(null);
   const [toastMsg, setToastMsg] = useState<string | null>(null);
   const toast = (msg: string) => setToastMsg(msg);
+
+  // File drag-and-drop state
+  const [isDragActive, setIsDragActive] = useState(false);
+  const dragCounterRef = useRef(0);
   /* ---------------------------------------------------------- */
 
   /* -------------------- Helper functions -------------------- */
@@ -255,6 +267,51 @@ export function NewTabPage({ user, signIn, signOut }: NewTabPageProps): ReactEle
     clearAuthHash();
     try { window.location.reload(); } catch {}
   };
+
+  /**
+   * Process a file dropped onto the main page and import its bookmarks directly.
+   * Supports .json (Mindful/Tabme/Toby/generic) and .html (Chrome Netscape) exports.
+   * Creates a new workspace per imported workspace entry, then opens and animates the
+   * workspaces pane to highlight the newly created workspaces.
+   *
+   * @param file The dropped file to import.
+   */
+  const handleFileDrop = useCallback(async (file: File) => {
+    const isJson = file.name.endsWith('.json') || file.type === 'application/json';
+    const isHtml = file.name.endsWith('.html') || file.name.endsWith('.htm') || file.type === 'text/html';
+    if (!isJson && !isHtml) {
+      toast('Please drop a .json or .html bookmarks file.');
+      return;
+    }
+    if (!userId || !activeWorkspaceId) return;
+
+    const previousIds = Object.keys(workspaces ?? {});
+
+    try {
+      const text = await file.text();
+      const workspaceService = createWorkspaceServiceLocal(userId);
+      // Derive a clean workspace name from the file name (strip extension)
+      const workspaceName = file.name.replace(/\.(json|html?)$/i, '').trim() || 'Imported';
+      await commitManualImportIntoWorkspace({
+        selection: {
+          jsonData: text,
+          jsonFileName: file.name,
+          workspaceName,
+        },
+        purposes: [],
+        workspaceId: activeWorkspaceId,
+        purpose: 'personal',
+        workspaceService,
+      });
+      bumpWorkspacesVersion();
+      // Small delay lets WorkspaceSwitcher finish its async workspace-list reload before the
+      // post-import effect runs, so the newly created workspaces are visible to animate.
+      setTimeout(() => bumpPostImport(previousIds), 150);
+      toast('Bookmarks imported successfully!');
+    } catch (err: any) {
+      toast(`Import failed: ${err?.message ?? String(err)}`);
+    }
+  }, [userId, activeWorkspaceId, workspaces, bumpPostImport, bumpWorkspacesVersion]);
 
   /**
    * Execute a confirmed copy or move request emitted by the modal, then surface the result via toast.
@@ -449,6 +506,54 @@ export function NewTabPage({ user, signIn, signOut }: NewTabPageProps): ReactEle
   }, []);
 
   /**
+   * Attach window-level drag event listeners so files dragged from the OS file system trigger a
+   * full-page drop overlay. Only activates for native file drags (checks `dataTransfer.types`).
+   */
+  useEffect(() => {
+    function isFileDrag(e: DragEvent): boolean {
+      return Array.from(e.dataTransfer?.types ?? []).includes('Files');
+    }
+
+    function onDragEnter(e: DragEvent) {
+      if (!isFileDrag(e)) return;
+      e.preventDefault();
+      dragCounterRef.current++;
+      setIsDragActive(true);
+    }
+
+    function onDragLeave() {
+      dragCounterRef.current--;
+      if (dragCounterRef.current <= 0) {
+        dragCounterRef.current = 0;
+        setIsDragActive(false);
+      }
+    }
+
+    function onDragOver(e: DragEvent) {
+      if (isFileDrag(e)) e.preventDefault();
+    }
+
+    async function onDrop(e: DragEvent) {
+      e.preventDefault();
+      dragCounterRef.current = 0;
+      setIsDragActive(false);
+      const file = e.dataTransfer?.files?.[0];
+      if (file) await handleFileDrop(file);
+    }
+
+    window.addEventListener('dragenter', onDragEnter);
+    window.addEventListener('dragleave', onDragLeave);
+    window.addEventListener('dragover', onDragOver);
+    window.addEventListener('drop', onDrop);
+    return () => {
+      window.removeEventListener('dragenter', onDragEnter);
+      window.removeEventListener('dragleave', onDragLeave);
+      window.removeEventListener('dragover', onDragOver);
+      window.removeEventListener('drop', onDrop);
+    };
+  }, [handleFileDrop]);
+
+  /**
    * Register a window-level listener for copy-to modal open events so other surfaces can trigger the modal.
    */
   useEffect(() => {
@@ -473,7 +578,6 @@ export function NewTabPage({ user, signIn, signOut }: NewTabPageProps): ReactEle
     });
 
   // Only mount Analytics when signed in
-    // Only mount Analytics when signed in
   const content = (
     <div className="min-h-screen bg-gray-100 dark:bg-neutral-950 overflow-x-hidden">
       <TopBanner
@@ -484,6 +588,18 @@ export function NewTabPage({ user, signIn, signOut }: NewTabPageProps): ReactEle
         isSignedIn={isSignedIn /* prefer context-derived status over props */}
         onStorageModeChange={changeStorageMode}
       />
+
+      {/* Page-level file drop overlay */}
+      {isDragActive && (
+        <div className="page-drop-overlay">
+          <div className="page-drop-overlay-border" />
+          <div className="page-drop-overlay-card">
+            <i className="fa-solid fa-file-arrow-down page-drop-overlay-icon" aria-hidden="true" />
+            <p className="page-drop-overlay-title">Drop to import bookmarks</p>
+            <p className="page-drop-overlay-hint">.json or .html files supported</p>
+          </div>
+        </div>
+      )}
 
       {/* Workspace Switcher: fixed on left; reserve gutter for grid */}
       <div className="relative">

--- a/src/styles/NewTab.css
+++ b/src/styles/NewTab.css
@@ -110,6 +110,69 @@ a { margin-right: 5px; }
   opacity: 0.7;
 }
 
+/* Page-level file drop overlay */
+@keyframes page-drop-in {
+  from { opacity: 0; transform: scale(1.02); }
+  to   { opacity: 1; transform: scale(1); }
+}
+
+.page-drop-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(37, 99, 235, 0.12);
+  backdrop-filter: blur(6px);
+  pointer-events: none;
+  animation: page-drop-in 0.12s ease-out forwards;
+}
+
+.page-drop-overlay-border {
+  position: absolute;
+  inset: 12px;
+  border: 3px dashed rgba(59, 130, 246, 0.7);
+  border-radius: 20px;
+  pointer-events: none;
+}
+
+.page-drop-overlay-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 36px 52px;
+  border-radius: 20px;
+  background: white;
+  color: #1d4ed8;
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.2);
+}
+
+.dark .page-drop-overlay-card {
+  background: #171717;
+  color: #93c5fd;
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.5);
+}
+
+.page-drop-overlay-icon {
+  font-size: 2.5rem;
+  line-height: 1;
+}
+
+.page-drop-overlay-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.page-drop-overlay-hint {
+  font-size: 0.78rem;
+  opacity: 0.65;
+  margin: 0;
+}
+
 /* Forms */
 form { @apply flex flex-col gap-1 max-w-full min-w-[200px] p-0 box-border; }
 label { @apply block text-lg; }


### PR DESCRIPTION
## Summary
                                                                                                          
  Adds a full-page drag-and-drop overlay so users can import bookmarks by dropping a .json or .html file   
  directly onto the new-tab page, without opening the import modal.                                        
                                                                                                           
  What's new:                                       
  - When a file is dragged over the page, a full-screen overlay appears with a dashed border, icon, and
  "Drop to import bookmarks" prompt                                                                        
  - Dropping a .json or .html bookmarks file runs the existing `commitManualImportIntoWorkspace` pipeline
  (supports Mindful, Tabme, Toby, Chrome Netscape HTML formats)                                            
  - The workspace name is derived from the file name (extension stripped)                                  
  - On success: bumps workspace version, animates newly created workspaces via bumpPostImport, and shows a
  success toast                                                                                            
  - On failure: shows an error toast with the message                                                      
  - Non-file drags (e.g. dragging text or links) are ignored — the overlay only activates for OS file drags
                                                                                                           
  Tests added (11 new cases in `NewTabPage.test.tsx`):                                                       
  - Overlay appears on file dragenter, hidden for non-file drags                                           
  - Nested dragenter/dragleave counter logic (overlay stays until counter reaches zero)                    
  - Overlay clears on drop                                                                                 
  - `commitManualImportIntoWorkspace` called with correct args for .json and .html files                     
  - Workspace name correctly strips file extension                                                         
  - Success toast and `bumpWorkspacesVersion` called after successful drop                                   
  - `bumpPostImport` called with previous workspace IDs after 150 ms delay                                   
  - Error toast for unsupported file type                                                                  
  - Error toast when import throws   