### PR TITLE
feat: AI Organize button for current workspace

### DIFF
--- a/public/privacy/index.html
+++ b/public/privacy/index.html
@@ -49,7 +49,7 @@
 <body>
   <main>
     <h1>Privacy Policy for Mindful Bookmarks</h1>
-<p><strong>Effective date:</strong> 2026-04-10</p>
+<p><strong>Effective date:</strong> 2026-04-11</p>
 <p>Mindful Bookmarks (“Mindful,” “we,” “us”) gives you control over your data. You can use Mindful entirely <strong>offline</strong> in <em>Local-Only mode</em>, with no login and no data leaving your device, or optionally turn on <strong>Encrypted Sync</strong> to back up and sync your bookmarks securely across devices.</p>
 <hr>
 <h2>Storage Options</h2>
@@ -145,7 +145,7 @@ Email: <code>privacy@mindfulbookmarks.com</code></p>
 <hr>
 <h2>Changes to This Policy</h2>
 <p>We may update this Privacy Policy to reflect product or legal changes. The “Effective date” above will always show the latest version. If changes are material, we will provide notice within the app.</p>
-<p><em>Last updated: 2026-04-10</em></p>
+<p><em>Last updated: 2026-04-11</em></p>
 
   </main>
 </body>

--- a/src/__tests__/components/OrganizeBanner.test.tsx
+++ b/src/__tests__/components/OrganizeBanner.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { OrganizeBanner } from '@/components/OrganizeBanner';
+
+describe('OrganizeBanner', () => {
+  test('renders an undo button while organizing and calls onUndo', () => {
+    const onUndo = jest.fn();
+
+    render(
+      <OrganizeBanner
+        visible={true}
+        backendPhase="categorizing"
+        succeeded={false}
+        onUndo={onUndo}
+      />
+    );
+
+    fireEvent.click(screen.getAllByRole('button', { name: /undo/i })[0]);
+    expect(onUndo).toHaveBeenCalledTimes(1);
+  });
+
+  test('renders an undo button on the success card and calls onUndo', () => {
+    const onUndo = jest.fn();
+
+    render(
+      <OrganizeBanner
+        visible={true}
+        backendPhase="done"
+        succeeded={true}
+        onUndo={onUndo}
+      />
+    );
+
+    fireEvent.click(screen.getAllByRole('button', { name: /undo/i })[1]);
+    expect(onUndo).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/pages/NewTabPage.test.tsx
+++ b/src/__tests__/pages/NewTabPage.test.tsx
@@ -49,6 +49,7 @@ jest.mock('@/scripts/import/workspaceServiceLocal', () => ({
 jest.mock('@/scripts/import/commitManualImportIntoWorkspace', () => ({
   commitManualImportIntoWorkspace: jest.fn(),
 }));
+
 const useImportBookmarksMock =
   useImportBookmarksDefault as unknown as jest.MockedFunction<typeof useImportBookmarksDefault>;
 
@@ -222,12 +223,17 @@ jest.mock('@/components/TopBanner', () => ({
   default: (props: {
     onExportBookmarks: () => void;
     onSignOut: () => void;
+    onOrganize?: () => void;
     onStorageModeChange?: (mode: StorageModeType) => void;
     isSignedIn: boolean;
+    isOrganizing?: boolean;
     userAttributes?: { email?: string };
   }) => (
     <div data-testid="top-banner">
       <button type="button" onClick={props.onExportBookmarks}>Export Bookmarks</button>
+      <button type="button" onClick={props.onOrganize} disabled={props.isOrganizing}>
+        Organize Workspace
+      </button>
       <button type="button" onClick={props.onSignOut}>Sign Out</button>
       <span>{`Signed In: ${props.isSignedIn}`}</span>
       <span>{props.userAttributes?.email}</span>
@@ -320,6 +326,7 @@ describe.each([
   let mockExportBookmarksToJSON: jest.Mock;
   let mockImportBookmarksFromJSON: jest.Mock;
   let mockChangeStorageMode: jest.Mock;
+  let mockUpdateAndPersistGroups: jest.Mock;
   let mockOpenImport: jest.Mock;
   let mockCloseImport: jest.Mock;
   let mockRenderModal: jest.Mock;
@@ -337,6 +344,9 @@ describe.each([
     mockExportBookmarksToJSON = jest.fn();
     mockImportBookmarksFromJSON = jest.fn();
     mockChangeStorageMode = jest.fn();
+    mockUpdateAndPersistGroups = jest.fn(async (updater?: () => unknown) => (
+      typeof updater === 'function' ? updater() : undefined
+    ));
 
     const mockHandleUploadJson = jest.fn<Promise<void>, [File]>(async () => {});
     const mockHandleImportChrome = jest.fn<Promise<void>, []>(async () => {});
@@ -363,6 +373,7 @@ describe.each([
       exportBookmarksToJSON: mockExportBookmarksToJSON,
       importBookmarksFromJSON: mockImportBookmarksFromJSON,
       changeStorageMode: mockChangeStorageMode,
+      updateAndPersistGroups: mockUpdateAndPersistGroups,
     });
 
     // Seed the real loader used by the provider
@@ -514,6 +525,52 @@ describe.each([
     fireEvent.click(screen.getByText('Sign Out'));
     expect(mockSignOut).toHaveBeenCalledTimes(1);
   });
+
+  it('organizes only the active workspace when the AI Organize button is clicked', async () => {
+    const workspaceGroups = [
+      {
+        id: 'g1',
+        groupName: 'Work',
+        bookmarks: [{ id: 'b1', name: 'Doc', url: 'https://docs.com', faviconUrl: 'https://docs.com/favicon.ico' }],
+      },
+      {
+        id: 'g2',
+        groupName: 'Personal',
+        bookmarks: [{ id: 'b2', name: 'Mail', url: 'https://mail.com' }],
+      },
+    ];
+    bookmarksDataMock.loadInitialBookmarks.mockResolvedValue(workspaceGroups as any);
+
+    render(
+      <AppContextProvider user={mockUser}>
+        <NewTabPage user={mockUser} />
+      </AppContextProvider>
+    );
+
+    await screen.findByTestId('top-banner');
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /organize workspace/i }));
+    });
+
+    await waitFor(() => {
+      expect(mockUpdateAndPersistGroups).toHaveBeenCalledWith(expect.any(Function));
+    });
+
+    const buildNextGroups = mockUpdateAndPersistGroups.mock.calls[0][0];
+    expect(
+      buildNextGroups().map((group: { groupName: string; bookmarks: Array<{ id: string; faviconUrl?: string }> }) => ({
+        groupName: group.groupName,
+        bookmarkIds: group.bookmarks.map(bookmark => bookmark.id),
+        firstBookmarkFavicon: group.bookmarks[0]?.faviconUrl,
+      }))
+    ).toEqual([
+      {
+        groupName: 'Imported',
+        bookmarkIds: ['b1', 'b2'],
+        firstBookmarkFavicon: 'https://docs.com/favicon.ico',
+      },
+    ]);
+  });
 });
 
 /* ------------------------------------------------------------------ */
@@ -591,6 +648,7 @@ describe('NewTabPage file drag-and-drop', () => {
       exportBookmarksToJSON: jest.fn(),
       importBookmarksFromJSON: jest.fn(),
       changeStorageMode: jest.fn(),
+      updateAndPersistGroups: jest.fn(),
     });
     useImportBookmarksMock.mockReturnValue({
       openImport: jest.fn(),

--- a/src/__tests__/pages/NewTabPage.test.tsx
+++ b/src/__tests__/pages/NewTabPage.test.tsx
@@ -571,6 +571,52 @@ describe.each([
       },
     ]);
   });
+
+  it('restores the previous workspace groups when undo is clicked during organize', async () => {
+    const workspaceGroups = [
+      {
+        id: 'g1',
+        groupName: 'Work',
+        bookmarks: [{ id: 'b1', name: 'Doc', url: 'https://docs.com', faviconUrl: 'https://docs.com/favicon.ico' }],
+      },
+      {
+        id: 'g2',
+        groupName: 'Personal',
+        bookmarks: [{ id: 'b2', name: 'Mail', url: 'https://mail.com' }],
+      },
+    ];
+    bookmarksDataMock.loadInitialBookmarks.mockResolvedValue(workspaceGroups as any);
+
+    render(
+      <AppContextProvider user={mockUser}>
+        <NewTabPage user={mockUser} />
+      </AppContextProvider>
+    );
+
+    await screen.findByTestId('top-banner');
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /organize workspace/i }));
+    });
+
+    await waitFor(() => {
+      expect(mockUpdateAndPersistGroups).toHaveBeenCalledTimes(1);
+    });
+
+    const organizeButton = screen.getByRole('button', { name: /organize workspace/i });
+    expect(organizeButton).toBeDisabled();
+
+    await act(async () => {
+      fireEvent.click(screen.getAllByRole('button', { name: /undo/i })[0]);
+    });
+
+    await waitFor(() => {
+      expect(mockUpdateAndPersistGroups).toHaveBeenCalledTimes(2);
+    });
+
+    const restoreGroups = mockUpdateAndPersistGroups.mock.calls[1][0];
+    expect(restoreGroups()).toEqual(workspaceGroups);
+    expect(organizeButton).not.toBeDisabled();
+  });
 });
 
 /* ------------------------------------------------------------------ */

--- a/src/components/OrganizeBanner.tsx
+++ b/src/components/OrganizeBanner.tsx
@@ -1,0 +1,165 @@
+/* -------------------- Imports -------------------- */
+import React, { useEffect, useState } from 'react';
+
+/* Types */
+import type { ImportPhase } from '@/core/types/importPhase';
+
+/* Reuse the phase-smoothing hook from ImportProgress */
+import { useSmoothedPhase } from '@/components/shared/ImportProgress';
+/* ---------------------------------------------------------- */
+
+/* -------------------- Constants -------------------- */
+export const ORGANIZE_PHASE_SEQUENCE: readonly ImportPhase[] = [
+  'initializing',
+  'categorizing',
+  'persisting',
+  'done',
+] as const;
+
+/**
+ * Rotating micro-copy shown for each phase.
+ * Messages cycle every COPY_INTERVAL_MS while the phase is active.
+ */
+const ROTATING_COPY: Record<string, string[]> = {
+  initializing: [
+    'Scanning your bookmarks ...',
+    'Finding patterns across your links',
+  ],
+  categorizing: [
+    'Finding patterns across your links',
+    'Creating meaningful groups',
+    'Sorting links by theme',
+    'Building a cleaner structure',
+  ],
+  persisting: [
+    'Saving your workspace ...',
+    'Almost there ...',
+  ],
+  done: [
+    'All organized!',
+  ],
+};
+
+const COPY_INTERVAL_MS = 2000;
+/* ---------------------------------------------------------- */
+
+/* -------------------- Hooks -------------------- */
+/**
+ * Cycles through a list of strings on a fixed interval.
+ * Resets to index 0 whenever the message list changes (i.e. phase change).
+ */
+function useRotatingCopy(messages: string[]): string {
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    setIndex(0);
+    if (messages.length <= 1) return;
+    const id = setInterval(
+      () => setIndex(i => (i + 1) % messages.length),
+      COPY_INTERVAL_MS,
+    );
+    return () => clearInterval(id);
+  }, [messages]);
+
+  return messages[index] ?? messages[0] ?? '';
+}
+/* ---------------------------------------------------------- */
+
+/* -------------------- Component -------------------- */
+type OrganizeBannerProps = {
+  /** Controls the slide-in/out visibility. */
+  visible: boolean;
+  /** The current backend phase — smoothed visually by useSmoothedPhase. */
+  backendPhase: ImportPhase;
+  /** When true, crossfades from the organizing card to the success card. */
+  succeeded?: boolean;
+};
+
+export function OrganizeBanner({ visible, backendPhase, succeeded = false }: OrganizeBannerProps) {
+  const { visualPhase, visualPhaseIndex } = useSmoothedPhase(
+    ORGANIZE_PHASE_SEQUENCE,
+    backendPhase,
+  );
+
+  const messages = ROTATING_COPY[visualPhase] ?? ROTATING_COPY.initializing ?? [];
+  const rotatingCopy = useRotatingCopy(messages);
+
+  const progressPct = Math.round(
+    ((visualPhaseIndex + 1) / ORGANIZE_PHASE_SEQUENCE.length) * 100,
+  );
+
+  return (
+    /* Outer wrapper handles the slide-down/fade-in using max-height transition */
+    <div
+      className={`
+        overflow-hidden transition-all duration-500 ease-out
+        ${!visible ? 'max-h-0 opacity-0' : succeeded ? 'max-h-16 opacity-100' : 'max-h-32 opacity-100'}
+      `}
+    >
+      {/* Right-align the card within the content column */}
+      <div className="flex justify-end pr-4 pb-3 pt-1">
+        {/* Shared position container — both cards occupy the same slot */}
+        <div className="relative w-full max-w-sm">
+
+          {/* Organizing card — fades out when succeeded */}
+          <div
+            className={`
+              flex items-center gap-3
+              rounded-xl border border-blue-100 dark:border-blue-900
+              bg-blue-50 dark:bg-blue-950/40
+              px-4 py-3 shadow-sm
+              transition-opacity duration-500
+              ${succeeded ? 'opacity-0' : 'opacity-100'}
+            `}
+          >
+            {/* Spinner icon */}
+            <div className="shrink-0 text-blue-500 text-lg">
+              <i className="fas fa-spinner fa-spin" />
+            </div>
+
+            <div className="flex-1 min-w-0">
+              {/* Static title */}
+              <p className="text-sm font-medium text-neutral-800 dark:text-neutral-100 leading-tight">
+                Grouping related links into a cleaner structure
+              </p>
+
+              {/* Rotating micro-copy */}
+              <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-0.5 truncate">
+                {rotatingCopy}
+              </p>
+
+              {/* Progress bar */}
+              <div className="mt-2 h-1 w-full rounded-full bg-blue-100 dark:bg-blue-900 overflow-hidden">
+                <div
+                  className="h-full rounded-full bg-blue-500 transition-[width] duration-700 ease-out"
+                  style={{ width: `${progressPct}%` }}
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Success card — fades in when succeeded, absolutely overlays top of the organizing card */}
+          <div
+            className={`
+              absolute top-0 inset-x-0
+              flex items-center gap-3
+              rounded-xl border border-green-100 dark:border-green-900
+              bg-green-50 dark:bg-green-950/40
+              px-4 py-2 shadow-sm
+              transition-opacity duration-500
+              ${succeeded ? 'opacity-100' : 'opacity-0 pointer-events-none'}
+            `}
+          >
+            <div className="shrink-0 text-green-500 text-lg">
+              <i className="fas fa-circle-check" />
+            </div>
+            <p className="text-sm font-medium text-neutral-800 dark:text-neutral-100">
+              Workspace organized
+            </p>
+          </div>
+
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/OrganizeBanner.tsx
+++ b/src/components/OrganizeBanner.tsx
@@ -73,9 +73,11 @@ type OrganizeBannerProps = {
   backendPhase: ImportPhase;
   /** When true, crossfades from the organizing card to the success card. */
   succeeded?: boolean;
+  /** Called when the user clicks Undo in either card. */
+  onUndo?: () => void;
 };
 
-export function OrganizeBanner({ visible, backendPhase, succeeded = false }: OrganizeBannerProps) {
+export function OrganizeBanner({ visible, backendPhase, succeeded = false, onUndo }: OrganizeBannerProps) {
   const { visualPhase, visualPhaseIndex } = useSmoothedPhase(
     ORGANIZE_PHASE_SEQUENCE,
     backendPhase,
@@ -120,7 +122,7 @@ export function OrganizeBanner({ visible, backendPhase, succeeded = false }: Org
             <div className="flex-1 min-w-0">
               {/* Static title */}
               <p className="text-sm font-medium text-neutral-800 dark:text-neutral-100 leading-tight">
-                Grouping related links into a cleaner structure
+                Grouping related links
               </p>
 
               {/* Rotating micro-copy */}
@@ -136,6 +138,15 @@ export function OrganizeBanner({ visible, backendPhase, succeeded = false }: Org
                 />
               </div>
             </div>
+
+            {onUndo && (
+              <button
+                onClick={onUndo}
+                className="cursor-pointer shrink-0 text-xs text-blue-600 dark:text-blue-400 hover:underline focus-visible:outline-none"
+              >
+                Undo
+              </button>
+            )}
           </div>
 
           {/* Success card — fades in when succeeded, absolutely overlays top of the organizing card */}
@@ -153,9 +164,17 @@ export function OrganizeBanner({ visible, backendPhase, succeeded = false }: Org
             <div className="shrink-0 text-green-500 text-lg">
               <i className="fas fa-circle-check" />
             </div>
-            <p className="text-sm font-medium text-neutral-800 dark:text-neutral-100">
+            <p className="flex-1 text-sm font-medium text-neutral-800 dark:text-neutral-100">
               Workspace organized
             </p>
+            {onUndo && (
+              <button
+                onClick={onUndo}
+                className="cursor-pointer shrink-0 text-xs text-green-700 dark:text-green-400 hover:underline focus-visible:outline-none"
+              >
+                Undo
+              </button>
+            )}
           </div>
 
         </div>

--- a/src/components/TopBanner.jsx
+++ b/src/components/TopBanner.jsx
@@ -19,7 +19,9 @@ const TopBanner = ({
   onSignIn,
   onSignOut,
   isSignedIn,
-  onStorageModeChange
+  onStorageModeChange,
+  onOrganize = () => {},
+  isOrganizing = false,
 }) => {
   /* -------------------- Context / state -------------------- */
   const { openOnboarding, storageMode = DEFAULT_STORAGE_MODE } = useContext(AppContext);
@@ -65,7 +67,32 @@ const TopBanner = ({
         <LogoComponent />
 
         {/* Right: icons + avatar */}
-        <nav className="hidden items-right gap-6 md:flex">
+        <nav className="hidden items-center gap-3 md:flex">
+          <Tooltip label="Group and clean up your links">
+            <button
+              onClick={onOrganize}
+              disabled={isOrganizing}
+              className="cursor-pointer inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg
+                         text-sm font-medium
+                         text-neutral-700 dark:text-neutral-200
+                         bg-white dark:bg-neutral-800
+                         border border-neutral-200 dark:border-neutral-700
+                         hover:bg-neutral-50 dark:hover:bg-neutral-700
+                         shadow-sm transition-colors
+                         disabled:opacity-60 disabled:cursor-not-allowed
+                         focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/60"
+              aria-label="Organize workspace with AI"
+            >
+              {isOrganizing
+                ? <i className="fas fa-spinner fa-spin text-blue-500" />
+                : <i className="fas fa-wand-magic-sparkles text-blue-500" />
+              }
+              {isOrganizing ? 'Organizing ...' : 'Organize'}
+            </button>
+          </Tooltip>
+
+          <div className="w-px h-5 bg-neutral-200 dark:bg-neutral-700" />
+
         <Tooltip label="Onboarding">
           <button
             onClick={openOnboarding} 

--- a/src/pages/NewTabPage.tsx
+++ b/src/pages/NewTabPage.tsx
@@ -30,6 +30,11 @@ import { AppContext } from "@/scripts/AppContextProvider";
 import { copyItems, moveItems } from "@/scripts/copyBookmarks";
 import { commitManualImportIntoWorkspace } from '@/scripts/import/commitManualImportIntoWorkspace';
 import { createWorkspaceServiceLocal } from '@/scripts/import/workspaceServiceLocal';
+import { remoteGroupingLLM } from '@/scripts/import/groupingLLMRemote';
+
+/* Constants */
+import { ImportSource } from '@/core/constants/import';
+import { PurposeId } from '@shared/constants/purposeId';
 
 /* Components */
 import TopBanner from "@/components/TopBanner";
@@ -37,6 +42,8 @@ import DraggableGrid, { GridHandle } from '@/components/DraggableGrid';
 import { WorkspaceSwitcher } from "@/components/WorkspaceSwitcher";
 import CopyToModal from "@/components/modals/CopyToModal";
 import { Toast } from "@/components/primitives/Toast";
+import { OrganizeBanner, ORGANIZE_PHASE_SEQUENCE } from '@/components/OrganizeBanner';
+import type { ImportPhase } from '@/core/types/importPhase';
 
 /* Events */
 import { openCopyTo, type CopyPayload } from "@/scripts/events/copyToBridge";
@@ -59,6 +66,7 @@ type AppCtxShape = {
   workspaces: Record<string, any>;
   bumpPostImport: (previousIds: string[]) => void;
   bumpWorkspacesVersion: () => void;
+  onboardingPurposes: string[];
 };
 
 type NewTabPageProps = {
@@ -111,6 +119,7 @@ export function NewTabPage({ user, signIn, signOut }: NewTabPageProps): ReactEle
     workspaces,
     bumpPostImport,
     bumpWorkspacesVersion,
+    onboardingPurposes,
   } = useContext(AppContext) as AppCtxShape;
 
   const gridRef = useRef<GridHandle | null>(null);
@@ -127,10 +136,14 @@ export function NewTabPage({ user, signIn, signOut }: NewTabPageProps): ReactEle
     exportBookmarksToJSON,
     importBookmarksFromJSON,
     changeStorageMode,
+    updateAndPersistGroups,
   } = useBookmarkManager();
 
   // Copy modal state + pending request
   const [copyOpen, setCopyOpen] = useState(false);
+  const [isOrganizing, setIsOrganizing] = useState(false);
+  const [organizePhase, setOrganizePhase] = useState<ImportPhase>('initializing');
+  const [organizeSucceeded, setOrganizeSucceeded] = useState(false);
   const pendingCopyRef = useRef<CopyPayload | null>(null);
   const [toastMsg, setToastMsg] = useState<string | null>(null);
   const toast = (msg: string) => setToastMsg(msg);
@@ -312,6 +325,80 @@ export function NewTabPage({ user, signIn, signOut }: NewTabPageProps): ReactEle
       toast(`Import failed: ${err?.message ?? String(err)}`);
     }
   }, [userId, activeWorkspaceId, workspaces, bumpPostImport, bumpWorkspacesVersion]);
+
+  /**
+   * Reorganize all bookmarks in the current workspace using AI grouping.
+   * Flattens every bookmark into RawItems, sends them to the grouping API,
+   * then replaces the workspace groups with the AI-suggested grouping.
+   */
+  const organizeWorkspace = useCallback(async () => {
+    if (isOrganizing || !bookmarkGroupsRaw) return;
+
+    const realGroups = bookmarkGroupsRaw.filter(g => g.groupName !== EMPTY_GROUP_IDENTIFIER);
+    const allBookmarks = realGroups.flatMap(g => g.bookmarks ?? []);
+
+    if (allBookmarks.length === 0) {
+      toast('No bookmarks to organize.');
+      return;
+    }
+
+    // Build a lookup map so we can restore full BookmarkType (faviconUrl, etc.) after grouping
+    const bookmarkById = new Map<string, BookmarkType>();
+    for (const bm of allBookmarks) {
+      bookmarkById.set(bm.id, bm);
+    }
+
+    const rawItems = allBookmarks.map(bm => ({
+      id: bm.id,
+      name: bm.name ?? bm.url,
+      url: bm.url,
+      source: ImportSource.Bookmarks as any,
+    }));
+
+    const purposes = onboardingPurposes?.length
+      ? onboardingPurposes
+      : [PurposeId.Personal];
+
+    setOrganizePhase('initializing');
+    setIsOrganizing(true);
+    try {
+      // Phase: categorizing — API call is now in flight
+      setOrganizePhase('categorizing');
+      const result = await remoteGroupingLLM.group({ items: rawItems, purposes: purposes as any });
+
+      // Phase: persisting — write new groups to storage
+      setOrganizePhase('persisting');
+      const emptyGroup = bookmarkGroupsRaw.find(g => g.groupName === EMPTY_GROUP_IDENTIFIER);
+      await updateAndPersistGroups(() => {
+        const newGroups: BookmarkGroupType[] = result.groups
+          .filter(cg => cg.items.length > 0)
+          .map(cg => ({
+            id: crypto.randomUUID(),
+            groupName: cg.name,
+            bookmarks: cg.items.map(item =>
+              bookmarkById.get(item.id) ?? { id: item.id, name: item.name, url: item.url }
+            ),
+          }));
+
+        if (emptyGroup) newGroups.push(emptyGroup);
+        return newGroups;
+      });
+
+      // Phase: done — crossfade to success card, then slide the whole banner out
+      setOrganizePhase('done');
+      await new Promise(r => setTimeout(r, 600));  // let 'done' phase register
+      setOrganizeSucceeded(true);                  // success card fades in, organizing card fades out
+      await new Promise(r => setTimeout(r, 2000)); // hold success state
+      setIsOrganizing(false);                      // slide banner out
+      await new Promise(r => setTimeout(r, 500));  // wait for slide-out to finish
+      setOrganizeSucceeded(false);                 // reset for next run
+    } catch (err: any) {
+      toast(`Couldn't organize workspace: ${err?.message ?? String(err)}`);
+    } finally {
+      setIsOrganizing(false);
+      setOrganizePhase('initializing'); // reset for next run
+    }
+  }, [isOrganizing, bookmarkGroupsRaw, onboardingPurposes, updateAndPersistGroups]);
 
   /**
    * Execute a confirmed copy or move request emitted by the modal, then surface the result via toast.
@@ -587,6 +674,8 @@ export function NewTabPage({ user, signIn, signOut }: NewTabPageProps): ReactEle
         onSignOut={signOut || defaultSignOut}
         isSignedIn={isSignedIn /* prefer context-derived status over props */}
         onStorageModeChange={changeStorageMode}
+        onOrganize={organizeWorkspace}
+        isOrganizing={isOrganizing}
       />
 
       {/* Page-level file drop overlay */}
@@ -613,6 +702,12 @@ export function NewTabPage({ user, signIn, signOut }: NewTabPageProps): ReactEle
               transition-[padding-left]
             "
           >
+            <OrganizeBanner
+              visible={isOrganizing}
+              backendPhase={organizePhase}
+              succeeded={organizeSucceeded}
+            />
+
             <DraggableGrid
               ref={gridRef as any}
               user={isSignedIn ? { sub: userId as string } : null}

--- a/src/pages/NewTabPage.tsx
+++ b/src/pages/NewTabPage.tsx
@@ -144,6 +144,10 @@ export function NewTabPage({ user, signIn, signOut }: NewTabPageProps): ReactEle
   const [isOrganizing, setIsOrganizing] = useState(false);
   const [organizePhase, setOrganizePhase] = useState<ImportPhase>('initializing');
   const [organizeSucceeded, setOrganizeSucceeded] = useState(false);
+  // Snapshot of groups captured before each organize run — used by Undo.
+  const preOrganizeSnapshotRef = useRef<BookmarkGroupType[] | null>(null);
+  // Incremented each run; lets the async flow detect when Undo has invalidated it.
+  const organizeRunRef = useRef(0);
   const pendingCopyRef = useRef<CopyPayload | null>(null);
   const [toastMsg, setToastMsg] = useState<string | null>(null);
   const toast = (msg: string) => setToastMsg(msg);
@@ -330,6 +334,9 @@ export function NewTabPage({ user, signIn, signOut }: NewTabPageProps): ReactEle
    * Reorganize all bookmarks in the current workspace using AI grouping.
    * Flattens every bookmark into RawItems, sends them to the grouping API,
    * then replaces the workspace groups with the AI-suggested grouping.
+   *
+   * Uses organizeRunRef to detect stale runs — if the user clicks Undo mid-flight,
+   * each await resumes to a stale run ID and exits early without updating state.
    */
   const organizeWorkspace = useCallback(async () => {
     if (isOrganizing || !bookmarkGroupsRaw) return;
@@ -359,12 +366,18 @@ export function NewTabPage({ user, signIn, signOut }: NewTabPageProps): ReactEle
       ? onboardingPurposes
       : [PurposeId.Personal];
 
+    // Snapshot current groups so Undo can restore them
+    preOrganizeSnapshotRef.current = [...bookmarkGroupsRaw];
+    const runId = ++organizeRunRef.current;
+    const isStale = () => organizeRunRef.current !== runId;
+
     setOrganizePhase('initializing');
     setIsOrganizing(true);
     try {
       // Phase: categorizing — API call is now in flight
       setOrganizePhase('categorizing');
       const result = await remoteGroupingLLM.group({ items: rawItems, purposes: purposes as any });
+      if (isStale()) return; // Undo clicked before data was written — just bail
 
       // Phase: persisting — write new groups to storage
       setOrganizePhase('persisting');
@@ -384,21 +397,55 @@ export function NewTabPage({ user, signIn, signOut }: NewTabPageProps): ReactEle
         return newGroups;
       });
 
+      if (isStale()) {
+        // Undo clicked after data was written — revert immediately
+        const snapshot = preOrganizeSnapshotRef.current;
+        if (snapshot) await updateAndPersistGroups(() => snapshot);
+        return;
+      }
+
       // Phase: done — crossfade to success card, then slide the whole banner out
       setOrganizePhase('done');
       await new Promise(r => setTimeout(r, 600));  // let 'done' phase register
+      if (isStale()) return;
+
       setOrganizeSucceeded(true);                  // success card fades in, organizing card fades out
-      await new Promise(r => setTimeout(r, 2000)); // hold success state
+      await new Promise(r => setTimeout(r, 4000)); // hold success state
+      if (isStale()) return;
+
       setIsOrganizing(false);                      // slide banner out
       await new Promise(r => setTimeout(r, 500));  // wait for slide-out to finish
+      if (isStale()) return;
+
       setOrganizeSucceeded(false);                 // reset for next run
+      preOrganizeSnapshotRef.current = null;
     } catch (err: any) {
+      if (isStale()) return;
       toast(`Couldn't organize workspace: ${err?.message ?? String(err)}`);
     } finally {
-      setIsOrganizing(false);
-      setOrganizePhase('initializing'); // reset for next run
+      if (!isStale()) {
+        setIsOrganizing(false);
+        setOrganizePhase('initializing');
+      }
     }
   }, [isOrganizing, bookmarkGroupsRaw, onboardingPurposes, updateAndPersistGroups]);
+
+  /**
+   * Revert the workspace to the snapshot captured before the last organize run.
+   * Safe to call during or after organizing — incrementing organizeRunRef signals
+   * the in-flight async flow to exit without further state updates.
+   */
+  const undoOrganize = useCallback(async () => {
+    const snapshot = preOrganizeSnapshotRef.current;
+    organizeRunRef.current++;          // invalidate any in-flight organize run
+    setIsOrganizing(false);
+    setOrganizeSucceeded(false);
+    setOrganizePhase('initializing');
+    preOrganizeSnapshotRef.current = null;
+    if (snapshot) {
+      await updateAndPersistGroups(() => snapshot);
+    }
+  }, [updateAndPersistGroups]);
 
   /**
    * Execute a confirmed copy or move request emitted by the modal, then surface the result via toast.
@@ -706,6 +753,7 @@ export function NewTabPage({ user, signIn, signOut }: NewTabPageProps): ReactEle
               visible={isOrganizing}
               backendPhase={organizePhase}
               succeeded={organizeSucceeded}
+              onUndo={undoOrganize}
             />
 
             <DraggableGrid


### PR DESCRIPTION
## Summary

- Adds an **Organize** button to the top nav (wand-magic-sparkles icon, blue) that reorganizes all bookmarks in the current workspace using the existing AI grouping API
- Shows a slide-in progress banner below the nav while organizing, with rotating micro-copy and a phase-based progress bar
- When complete, the organizing card crossfades into a compact green success card ("Workspace organized!") in the same position, then the banner slides out — no bottom-right toast
- Error surfaces inline via toast if the API call fails ("Couldn't organize workspace: ...")

## Test plan

- [ ] Click Organize with bookmarks present — banner slides in, progress bar animates through phases, rotating copy updates every 2s
- [ ] After organizing completes, blue card fades out and green success card fades in at same position, then banner slides out after ~2s
- [ ] Click Organize with no bookmarks — toast fires immediately, no banner
- [ ] Organize button is disabled and shows spinner while in progress
- [ ] Verify full `BookmarkType` metadata (favicons, dates) is preserved after reorganization
- [ ] Verify the empty-group placeholder is preserved at the end of the new group list

🤖 Generated with [Claude Code](https://claude.com/claude-code)