### PR TITLE
Adding in-browser local LLMs to Mindful

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,8 @@ amplify_outputs.*.json
 
 .claude/
 .claudeignore
+
+apply_fixes.py
+changed_llm_context.py
+clean_llm_changes.py
+llm_context.py

--- a/Labs.html
+++ b/Labs.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/png" href="/assets/icon-128.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Mindful AI Labs</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/entrypoints/labs.tsx"></script>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
 				"@dnd-kit/modifiers": "^9.0.0",
 				"@dnd-kit/sortable": "^10.0.0",
 				"@fortawesome/fontawesome-free": "^7.0.1",
+				"@mlc-ai/web-llm": "^0.2.82",
 				"aws-amplify": "^6.15.4",
 				"clsx": "^2.1.1",
 				"crypto-js": "^4.2.0",
@@ -34432,6 +34433,15 @@
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
+		"node_modules/@mlc-ai/web-llm": {
+			"version": "0.2.82",
+			"resolved": "https://registry.npmjs.org/@mlc-ai/web-llm/-/web-llm-0.2.82.tgz",
+			"integrity": "sha512-ONhW+28PPVSUI1m0RkJcm7suwc47b65i5b/rTEIADq5I22p1+9uf/CBbDPRkkjj1WJB9s8oFp0ywAW0NY1G6fg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"loglevel": "^1.9.1"
+			}
+		},
 		"node_modules/@napi-rs/wasm-runtime": {
 			"version": "0.2.12",
 			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -47764,6 +47774,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/loglevel": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+			"integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6.0"
+			},
+			"funding": {
+				"type": "tidelift",
+				"url": "https://tidelift.com/funding/github/npm/loglevel"
 			}
 		},
 		"node_modules/long": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 		"@dnd-kit/modifiers": "^9.0.0",
 		"@dnd-kit/sortable": "^10.0.0",
 		"@fortawesome/fontawesome-free": "^7.0.1",
+		"@mlc-ai/web-llm": "^0.2.82",
 		"aws-amplify": "^6.15.4",
 		"clsx": "^2.1.1",
 		"crypto-js": "^4.2.0",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -51,6 +51,6 @@
   },
 
   "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'self'; connect-src 'self' https://cognito-idp.us-west-1.amazonaws.com https://cognito-identity.us-west-1.amazonaws.com https://kT7PGxGVd.auth.us-west-1.amazoncognito.com https://api.mindfulbookmarks.com https://app.posthog.com;"
+    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; connect-src 'self' https://cognito-idp.us-west-1.amazonaws.com https://cognito-identity.us-west-1.amazonaws.com https://kT7PGxGVd.auth.us-west-1.amazoncognito.com https://api.mindfulbookmarks.com https://app.posthog.com https://huggingface.co https://*.huggingface.co https://raw.githubusercontent.com;"
   }
 }

--- a/public/privacy/index.html
+++ b/public/privacy/index.html
@@ -49,7 +49,7 @@
 <body>
   <main>
     <h1>Privacy Policy for Mindful Bookmarks</h1>
-<p><strong>Effective date:</strong> 2026-04-11</p>
+<p><strong>Effective date:</strong> 2026-04-17</p>
 <p>Mindful Bookmarks (“Mindful,” “we,” “us”) gives you control over your data. You can use Mindful entirely <strong>offline</strong> in <em>Local-Only mode</em>, with no login and no data leaving your device, or optionally turn on <strong>Encrypted Sync</strong> to back up and sync your bookmarks securely across devices.</p>
 <hr>
 <h2>Storage Options</h2>
@@ -145,7 +145,7 @@ Email: <code>privacy@mindfulbookmarks.com</code></p>
 <hr>
 <h2>Changes to This Policy</h2>
 <p>We may update this Privacy Policy to reflect product or legal changes. The “Effective date” above will always show the latest version. If changes are material, we will provide notice within the app.</p>
-<p><em>Last updated: 2026-04-11</em></p>
+<p><em>Last updated: 2026-04-17</em></p>
 
   </main>
 </body>

--- a/src/__tests__/ai/aiClient.test.ts
+++ b/src/__tests__/ai/aiClient.test.ts
@@ -1,0 +1,59 @@
+import { aiClient } from '../../scripts/ai/aiClient';
+import { SUPPORTED_MODELS } from '../../scripts/ai/modelRegistry';
+
+class MockWorker {
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  
+  postMessage(data: any) {
+    // Simulate async processing
+    setTimeout(() => {
+      if (!this.onmessage) return;
+
+      if (data.type === 'INIT_MODEL') {
+        this.onmessage({ data: { type: 'INIT_PROGRESS', payload: { text: 'Loading', progress: 0.5 } } } as MessageEvent);
+        this.onmessage({ data: { type: 'INIT_COMPLETE' } } as MessageEvent);
+      } 
+      
+      if (data.type === 'GENERATE') {
+        this.onmessage({ data: { type: 'GENERATE_TOKEN', payload: { token: 'Hello ' } } } as MessageEvent);
+        this.onmessage({ data: { type: 'GENERATE_TOKEN', payload: { token: 'world' } } } as MessageEvent);
+        this.onmessage({ data: { type: 'GENERATE_COMPLETE', payload: { fullText: 'Hello world' } } } as MessageEvent);
+      }
+    }, 10);
+  }
+}
+
+// Intercept the factory import entirely
+jest.mock('../../scripts/ai/workerFactory', () => ({
+  createAIWorker: () => new MockWorker()
+}));
+
+describe('aiClient', () => {
+  it('should act as a singleton instance', () => {
+    expect(aiClient).toBeDefined();
+  });
+
+  it('should return available models matching the registry', () => {
+    const models = aiClient.getAvailableModels();
+    expect(models).toEqual(SUPPORTED_MODELS);
+  });
+
+  it('should initialize a model and emit progress events', async () => {
+    const progressMock = jest.fn();
+    aiClient.onProgress(progressMock);
+
+    await aiClient.selectModel('test-model-id');
+
+    expect(progressMock).toHaveBeenCalledWith({ text: 'Loading', progress: 0.5 });
+  });
+
+  it('should generate a response and emit streaming tokens', async () => {
+    const tokenMock = jest.fn();
+
+    await aiClient.generateResponse('Say hello', tokenMock);
+
+    expect(tokenMock).toHaveBeenCalledTimes(2);
+    expect(tokenMock).toHaveBeenNthCalledWith(1, 'Hello ');
+    expect(tokenMock).toHaveBeenNthCalledWith(2, 'world');
+  });
+});

--- a/src/__tests__/ai/modelRegistry.test.ts
+++ b/src/__tests__/ai/modelRegistry.test.ts
@@ -1,0 +1,21 @@
+import { SUPPORTED_MODELS } from '../../scripts/ai/modelRegistry';
+
+describe('modelRegistry', () => {
+  it('should export a non-empty array of models', () => {
+    expect(Array.isArray(SUPPORTED_MODELS)).toBe(true);
+    expect(SUPPORTED_MODELS.length).toBeGreaterThan(0);
+  });
+
+  it('should have required metadata properties on all models', () => {
+    SUPPORTED_MODELS.forEach((model) => {
+      expect(model).toHaveProperty('id');
+      expect(typeof model.id).toBe('string');
+      
+      expect(model).toHaveProperty('friendlyName');
+      expect(typeof model.friendlyName).toBe('string');
+      
+      expect(model).toHaveProperty('estimatedSize');
+      expect(typeof model.estimatedSize).toBe('string');
+    });
+  });
+});

--- a/src/__tests__/ai/progressHandler.test.ts
+++ b/src/__tests__/ai/progressHandler.test.ts
@@ -1,0 +1,19 @@
+import { parseProgressMessage } from '../../scripts/ai/progressHandler';
+
+describe('progressHandler', () => {
+  it('should parse standard progress correctly', () => {
+    const result = parseProgressMessage('Downloading...', 0.5);
+    expect(result.text).toBe('Downloading...');
+    expect(result.progress).toBe(0.5);
+  });
+
+  it('should clamp progress below 0 to 0', () => {
+    const result = parseProgressMessage('Starting...', -0.2);
+    expect(result.progress).toBe(0);
+  });
+
+  it('should clamp progress above 1 to 1', () => {
+    const result = parseProgressMessage('Done', 1.5);
+    expect(result.progress).toBe(1);
+  });
+});

--- a/src/__tests__/ai/webgpuDetector.test.ts
+++ b/src/__tests__/ai/webgpuDetector.test.ts
@@ -1,0 +1,72 @@
+import { checkWebGPUSupport } from '../../scripts/ai/webgpuDetector';
+
+describe('webgpuDetector', () => {
+  let originalNavigator: any;
+  let originalWarn: any;
+
+  beforeEach(() => {
+    originalNavigator = global.navigator;
+    originalWarn = console.warn;
+    console.warn = jest.fn(); // Suppress intentional failure logs during tests
+  });
+
+  afterEach(() => {
+    Object.defineProperty(global, 'navigator', {
+      value: originalNavigator,
+      writable: true,
+    });
+    console.warn = originalWarn; // Restore normal warning behavior
+  });
+
+  it('should return false if navigator.gpu is undefined', async () => {
+    Object.defineProperty(global, 'navigator', {
+      value: { gpu: undefined },
+      writable: true,
+    });
+
+    const result = await checkWebGPUSupport();
+    expect(result).toBe(false);
+  });
+
+  it('should return false if requestAdapter throws an error', async () => {
+    Object.defineProperty(global, 'navigator', {
+      value: {
+        gpu: {
+          requestAdapter: jest.fn().mockRejectedValue(new Error('GPU Not Allowed')),
+        },
+      },
+      writable: true,
+    });
+
+    const result = await checkWebGPUSupport();
+    expect(result).toBe(false);
+  });
+
+  it('should return false if requestAdapter returns null', async () => {
+    Object.defineProperty(global, 'navigator', {
+      value: {
+        gpu: {
+          requestAdapter: jest.fn().mockResolvedValue(null),
+        },
+      },
+      writable: true,
+    });
+
+    const result = await checkWebGPUSupport();
+    expect(result).toBe(false);
+  });
+
+  it('should return true if requestAdapter returns an adapter', async () => {
+    Object.defineProperty(global, 'navigator', {
+      value: {
+        gpu: {
+          requestAdapter: jest.fn().mockResolvedValue({ name: 'MockAdapter' }),
+        },
+      },
+      writable: true,
+    });
+
+    const result = await checkWebGPUSupport();
+    expect(result).toBe(true);
+  });
+});

--- a/src/entrypoints/labs.tsx
+++ b/src/entrypoints/labs.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import LabsPage from "@/pages/LabsPage";
+import "@/styles/Index.css";
+
+const container = document.getElementById("root");
+if (!container) throw new Error('Root element not found');
+const root = createRoot(container);
+
+root.render(
+  <React.StrictMode>
+    <LabsPage />
+  </React.StrictMode>
+);

--- a/src/hooks/useLocalLLM.ts
+++ b/src/hooks/useLocalLLM.ts
@@ -11,6 +11,10 @@ export function useLocalLLM() {
   const [isSupported, setIsSupported] = useState<boolean | null>(null);
   const [availableModels] = useState<ModelMetadata[]>(aiClient.getAvailableModels());
   const [selectedModelId, setSelectedModelId] = useState<string>(availableModels[0]?.id || '');
+  
+  const [isModelLoaded, setIsModelLoaded] = useState(false);
+  const [loadedModelId, setLoadedModelId] = useState<string | null>(null);
+  
   const [progress, setProgress] = useState<ProgressInfo | null>(null);
   const [isInitializing, setIsInitializing] = useState(false);
   const [isGenerating, setIsGenerating] = useState(false);
@@ -24,12 +28,22 @@ export function useLocalLLM() {
     aiClient.onProgress((p) => setProgress(p));
   }, []);
 
-  const loadModel = async () => {
+  // Returns a promise that resolves when the model is ready
+  const loadModel = async (modelIdToLoad?: string) => {
+    const targetId = modelIdToLoad || selectedModelId;
+    
+    // If already loaded, skip
+    if (isModelLoaded && loadedModelId === targetId) return true;
+
     setIsInitializing(true);
     try {
-      await aiClient.selectModel(selectedModelId);
+      await aiClient.selectModel(targetId);
+      setIsModelLoaded(true);
+      setLoadedModelId(targetId);
+      return true;
     } catch (err) {
       console.error("Initialization failed", err);
+      return false;
     } finally {
       setIsInitializing(false);
       setProgress(null);
@@ -37,15 +51,29 @@ export function useLocalLLM() {
   };
 
   const sendMessage = async (text: string) => {
-    if (!text.trim()) return;
+    const trimmedText = text.trim();
+    if (!trimmedText) return;
 
-    const newMessages: Message[] = [...messages, { role: 'user', content: text }];
-    setMessages([...newMessages, { role: 'assistant', content: '' }]);
+    // 1. Immediately show the user's message
+    const newMessages: Message[] = [...messages, { role: 'user', content: trimmedText }];
+    setMessages(newMessages);
+
+    // 2. Check if we need to load/download the model first
+    if (!isModelLoaded || loadedModelId !== selectedModelId) {
+      const success = await loadModel(selectedModelId);
+      if (!success) {
+        setMessages(prev => [...prev, { role: 'assistant', content: 'Error: Failed to load the local model.' }]);
+        return;
+      }
+    }
+
+    // 3. Trigger assistant response
+    setMessages(prev => [...prev, { role: 'assistant', content: '' }]);
     setIsGenerating(true);
 
     try {
       let fullResponse = "";
-      await aiClient.generateResponse(text, (token) => {
+      await aiClient.generateResponse(trimmedText, (token) => {
         fullResponse += token;
         setMessages((prev) => {
           const updated = [...prev];
@@ -58,6 +86,14 @@ export function useLocalLLM() {
       });
     } catch (err) {
       console.error("Generation failed", err);
+      setMessages(prev => {
+        const updated = [...prev];
+        const last = updated[updated.length - 1];
+        if (last && last.role === 'assistant') {
+            last.content = "Error: The model encountered an issue during generation.";
+        }
+        return updated;
+      });
     } finally {
       setIsGenerating(false);
     }
@@ -68,6 +104,7 @@ export function useLocalLLM() {
     availableModels,
     selectedModelId,
     setSelectedModelId,
+    isModelLoaded,
     progress,
     isInitializing,
     isGenerating,

--- a/src/hooks/useLocalLLM.ts
+++ b/src/hooks/useLocalLLM.ts
@@ -1,0 +1,78 @@
+import { useState, useEffect, useCallback } from 'react';
+import { aiClient } from '@/scripts/ai/aiClient';
+import { ProgressInfo, ModelMetadata } from '@/scripts/ai/ai.types';
+
+export type Message = {
+  role: 'user' | 'assistant';
+  content: string;
+};
+
+export function useLocalLLM() {
+  const [isSupported, setIsSupported] = useState<boolean | null>(null);
+  const [availableModels] = useState<ModelMetadata[]>(aiClient.getAvailableModels());
+  const [selectedModelId, setSelectedModelId] = useState<string>(availableModels[0]?.id || '');
+  const [progress, setProgress] = useState<ProgressInfo | null>(null);
+  const [isInitializing, setIsInitializing] = useState(false);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [messages, setMessages] = useState<Message[]>([]);
+
+  useEffect(() => {
+    aiClient.checkSupport().then(setIsSupported);
+  }, []);
+
+  useEffect(() => {
+    aiClient.onProgress((p) => setProgress(p));
+  }, []);
+
+  const loadModel = async () => {
+    setIsInitializing(true);
+    try {
+      await aiClient.selectModel(selectedModelId);
+    } catch (err) {
+      console.error("Initialization failed", err);
+    } finally {
+      setIsInitializing(false);
+      setProgress(null);
+    }
+  };
+
+  const sendMessage = async (text: string) => {
+    if (!text.trim()) return;
+
+    const newMessages: Message[] = [...messages, { role: 'user', content: text }];
+    setMessages([...newMessages, { role: 'assistant', content: '' }]);
+    setIsGenerating(true);
+
+    try {
+      let fullResponse = "";
+      await aiClient.generateResponse(text, (token) => {
+        fullResponse += token;
+        setMessages((prev) => {
+          const updated = [...prev];
+          const last = updated[updated.length - 1];
+          if (last && last.role === 'assistant') {
+            last.content = fullResponse;
+          }
+          return updated;
+        });
+      });
+    } catch (err) {
+      console.error("Generation failed", err);
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
+  return {
+    isSupported,
+    availableModels,
+    selectedModelId,
+    setSelectedModelId,
+    progress,
+    isInitializing,
+    isGenerating,
+    messages,
+    loadModel,
+    sendMessage
+  };
+}

--- a/src/pages/LabsPage.tsx
+++ b/src/pages/LabsPage.tsx
@@ -1,9 +1,9 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useLocalLLM } from '@/hooks/useLocalLLM';
 import { Button } from '@/components/primitives/button';
 import { Input } from '@/components/primitives/input';
 import { Badge } from '@/components/primitives/badge';
-import { Loader2, Send, Cpu } from 'lucide-react';
+import { Loader2, Send, Cpu, CheckCircle2 } from 'lucide-react';
 
 export default function LabsPage() {
   const {
@@ -11,6 +11,7 @@ export default function LabsPage() {
     availableModels,
     selectedModelId,
     setSelectedModelId,
+    isModelLoaded,
     progress,
     isInitializing,
     isGenerating,
@@ -20,9 +21,17 @@ export default function LabsPage() {
   } = useLocalLLM();
 
   const [input, setInput] = useState('');
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // Auto-scroll to bottom as messages stream in
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [messages, progress]);
 
   const handleSend = () => {
-    if (!input.trim() || isGenerating) return;
+    if (!input.trim() || isGenerating || isInitializing) return;
     sendMessage(input);
     setInput('');
   };
@@ -35,61 +44,83 @@ export default function LabsPage() {
           <Badge forceLight>
             {isSupported === null ? "Checking..." : isSupported ? "WebGPU Active" : "No WebGPU"}
           </Badge>
+          {isModelLoaded && !isInitializing && (
+            <div className="flex items-center gap-1 text-xs text-green-600 font-medium">
+              <CheckCircle2 size={14} /> Ready
+            </div>
+          )}
         </div>
         
         <div className="flex items-center gap-2">
           <select 
-            className="bg-neutral-100 dark:bg-neutral-800 rounded-md px-3 py-1.5 text-sm"
+            className="bg-neutral-100 dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 rounded-md px-3 py-1.5 text-sm outline-none focus:ring-2 focus:ring-blue-500"
             value={selectedModelId}
             onChange={(e) => setSelectedModelId(e.target.value)}
+            disabled={isInitializing || isGenerating}
           >
             {availableModels.map(m => (
               <option key={m.id} value={m.id}>{m.friendlyName}</option>
             ))}
           </select>
-          <Button onClick={loadModel} disabled={isInitializing} size="sm">
-            {isInitializing ? <Loader2 className="animate-spin h-4 w-4" /> : "Load Model"}
+          <Button onClick={() => loadModel()} disabled={isInitializing || isGenerating} size="sm" variant="outline">
+            {isInitializing ? <Loader2 className="animate-spin h-4 w-4" /> : "Pre-load Model"}
           </Button>
         </div>
       </header>
 
-      <main className="flex-1 overflow-y-auto p-6 space-y-4">
+      <main ref={scrollRef} className="flex-1 overflow-y-auto p-6 space-y-4">
         {!messages.length && !progress && (
           <div className="flex flex-col items-center justify-center h-full text-neutral-400">
             <Cpu size={48} className="mb-2 opacity-20" />
-            <p>Ready for local inference</p>
-          </div>
-        )}
-
-        {progress && (
-          <div className="max-w-md mx-auto p-6 bg-white dark:bg-neutral-900 rounded-2xl border border-blue-200">
-            <p className="text-sm font-medium mb-2">{progress.text}</p>
-            <div className="h-2 w-full bg-neutral-100 dark:bg-neutral-800 rounded-full overflow-hidden">
-              <div className="h-full bg-blue-600 transition-all" style={{ width: `${progress.progress * 100}%` }} />
-            </div>
+            <p className="text-center max-w-xs">Type a message to start. The model will download automatically if not already present.</p>
           </div>
         )}
 
         {messages.map((msg, i) => (
           <div key={i} className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}>
-            <div className={`max-w-[80%] px-4 py-2 rounded-2xl ${msg.role === 'user' ? 'bg-blue-600 text-white' : 'bg-neutral-200 dark:bg-neutral-800'}`}>
+            <div className={`max-w-[80%] px-4 py-2 shadow-sm rounded-2xl ${
+              msg.role === 'user' 
+                ? 'bg-blue-600 text-white rounded-tr-none' 
+                : 'bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 rounded-tl-none'
+            }`}>
               <p className="text-sm whitespace-pre-wrap">{msg.content}</p>
-              {msg.role === 'assistant' && !msg.content && <Loader2 className="animate-spin h-4 w-4 opacity-50" />}
+              {msg.role === 'assistant' && !msg.content && !isInitializing && (
+                <Loader2 className="animate-spin h-4 w-4 opacity-50" />
+              )}
             </div>
           </div>
         ))}
+
+        {isInitializing && progress && (
+          <div className="max-w-md mx-auto p-6 bg-white dark:bg-neutral-900 rounded-2xl border border-blue-200 shadow-lg animate-in fade-in slide-in-from-bottom-4">
+            <div className="flex items-center gap-2 mb-3">
+              <Loader2 className="animate-spin h-4 w-4 text-blue-600" />
+              <p className="text-sm font-semibold">{progress.text}</p>
+            </div>
+            <div className="h-2 w-full bg-neutral-100 dark:bg-neutral-800 rounded-full overflow-hidden">
+              <div 
+                className="h-full bg-blue-600 transition-all duration-500" 
+                style={{ width: `${progress.progress * 100}%` }} 
+              />
+            </div>
+            <p className="text-[10px] text-neutral-400 mt-2 text-center uppercase tracking-widest font-bold">
+              Downloading weights ({Math.round(progress.progress * 100)}%)
+            </p>
+          </div>
+        )}
       </main>
 
-      <footer className="p-6 bg-white dark:bg-neutral-900 border-t border-neutral-200">
+      <footer className="p-6 bg-white dark:bg-neutral-900 border-t border-neutral-200 dark:border-neutral-800">
         <div className="max-w-4xl mx-auto flex gap-2">
           <Input 
-            placeholder="Ask something..." 
+            placeholder={isInitializing ? "Downloading model..." : "Ask the local LLM..."}
             value={input}
             onChange={(e: any) => setInput(e.target.value)}
             onKeyDown={(e: any) => e.key === 'Enter' && handleSend()}
+            disabled={isInitializing}
           />
-          <Button onClick={handleSend} disabled={isGenerating || isInitializing}>
-            <Send size={18} />
+          <Button onClick={handleSend} disabled={isGenerating || isInitializing || !input.trim()}>
+            {isGenerating ? <Loader2 className="animate-spin h-4 w-4" /> : <Send size={18} />}
           </Button>
         </div>
       </footer>

--- a/src/pages/LabsPage.tsx
+++ b/src/pages/LabsPage.tsx
@@ -1,0 +1,98 @@
+import React, { useState } from 'react';
+import { useLocalLLM } from '@/hooks/useLocalLLM';
+import { Button } from '@/components/primitives/button';
+import { Input } from '@/components/primitives/input';
+import { Badge } from '@/components/primitives/badge';
+import { Loader2, Send, Cpu } from 'lucide-react';
+
+export default function LabsPage() {
+  const {
+    isSupported,
+    availableModels,
+    selectedModelId,
+    setSelectedModelId,
+    progress,
+    isInitializing,
+    isGenerating,
+    messages,
+    loadModel,
+    sendMessage
+  } = useLocalLLM();
+
+  const [input, setInput] = useState('');
+
+  const handleSend = () => {
+    if (!input.trim() || isGenerating) return;
+    sendMessage(input);
+    setInput('');
+  };
+
+  return (
+    <div className="flex flex-col h-screen bg-neutral-50 dark:bg-neutral-950 text-neutral-900 dark:text-neutral-100 font-sans">
+      <header className="flex items-center justify-between px-6 py-4 border-b border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900">
+        <div className="flex items-center gap-3">
+          <h1 className="text-xl font-bold">Mindful AI Labs</h1>
+          <Badge forceLight>
+            {isSupported === null ? "Checking..." : isSupported ? "WebGPU Active" : "No WebGPU"}
+          </Badge>
+        </div>
+        
+        <div className="flex items-center gap-2">
+          <select 
+            className="bg-neutral-100 dark:bg-neutral-800 rounded-md px-3 py-1.5 text-sm"
+            value={selectedModelId}
+            onChange={(e) => setSelectedModelId(e.target.value)}
+          >
+            {availableModels.map(m => (
+              <option key={m.id} value={m.id}>{m.friendlyName}</option>
+            ))}
+          </select>
+          <Button onClick={loadModel} disabled={isInitializing} size="sm">
+            {isInitializing ? <Loader2 className="animate-spin h-4 w-4" /> : "Load Model"}
+          </Button>
+        </div>
+      </header>
+
+      <main className="flex-1 overflow-y-auto p-6 space-y-4">
+        {!messages.length && !progress && (
+          <div className="flex flex-col items-center justify-center h-full text-neutral-400">
+            <Cpu size={48} className="mb-2 opacity-20" />
+            <p>Ready for local inference</p>
+          </div>
+        )}
+
+        {progress && (
+          <div className="max-w-md mx-auto p-6 bg-white dark:bg-neutral-900 rounded-2xl border border-blue-200">
+            <p className="text-sm font-medium mb-2">{progress.text}</p>
+            <div className="h-2 w-full bg-neutral-100 dark:bg-neutral-800 rounded-full overflow-hidden">
+              <div className="h-full bg-blue-600 transition-all" style={{ width: `${progress.progress * 100}%` }} />
+            </div>
+          </div>
+        )}
+
+        {messages.map((msg, i) => (
+          <div key={i} className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}>
+            <div className={`max-w-[80%] px-4 py-2 rounded-2xl ${msg.role === 'user' ? 'bg-blue-600 text-white' : 'bg-neutral-200 dark:bg-neutral-800'}`}>
+              <p className="text-sm whitespace-pre-wrap">{msg.content}</p>
+              {msg.role === 'assistant' && !msg.content && <Loader2 className="animate-spin h-4 w-4 opacity-50" />}
+            </div>
+          </div>
+        ))}
+      </main>
+
+      <footer className="p-6 bg-white dark:bg-neutral-900 border-t border-neutral-200">
+        <div className="max-w-4xl mx-auto flex gap-2">
+          <Input 
+            placeholder="Ask something..." 
+            value={input}
+            onChange={(e: any) => setInput(e.target.value)}
+            onKeyDown={(e: any) => e.key === 'Enter' && handleSend()}
+          />
+          <Button onClick={handleSend} disabled={isGenerating || isInitializing}>
+            <Send size={18} />
+          </Button>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/src/scripts/ai/ai.types.ts
+++ b/src/scripts/ai/ai.types.ts
@@ -1,0 +1,26 @@
+export interface ModelMetadata {
+  id: string;
+  friendlyName: string;
+  estimatedSize: string;
+}
+
+export interface ProgressInfo {
+  text: string;
+  progress: number; // 0 to 1 scale
+}
+
+// Requests from Main Thread -> Worker
+export type WorkerRequest =
+  | { type: 'INIT_MODEL'; payload: { modelId: string } }
+  | { type: 'GENERATE'; payload: { prompt: string } }
+  | { type: 'CHECK_SUPPORT' };
+
+// Responses from Worker -> Main Thread
+export type WorkerResponse =
+  | { type: 'INIT_PROGRESS'; payload: ProgressInfo }
+  | { type: 'INIT_COMPLETE' }
+  | { type: 'INIT_ERROR'; error: string }
+  | { type: 'GENERATE_TOKEN'; payload: { token: string } }
+  | { type: 'GENERATE_COMPLETE'; payload: { fullText: string } }
+  | { type: 'GENERATE_ERROR'; error: string }
+  | { type: 'SUPPORT_RESULT'; payload: { isSupported: boolean } };

--- a/src/scripts/ai/ai.worker.ts
+++ b/src/scripts/ai/ai.worker.ts
@@ -1,0 +1,68 @@
+/// <reference lib="webworker" />
+import { MLCEngine, InitProgressReport } from '@mlc-ai/web-llm';
+import { WorkerRequest, WorkerResponse } from './ai.types';
+import { parseProgressMessage } from './progressHandler';
+
+let engine: MLCEngine | null = null;
+
+self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
+  const req = event.data;
+
+  try {
+    switch (req.type) {
+      case 'INIT_MODEL': {
+        // Instantiate the engine and set up the progress hook natively supported by Web-LLM
+        engine = new MLCEngine();
+        engine.setInitProgressCallback((report: InitProgressReport) => {
+          postMessage({
+            type: 'INIT_PROGRESS',
+            payload: parseProgressMessage(report.text, report.progress)
+          } as WorkerResponse);
+        });
+
+        // Pulls weights from HuggingFace and caches them locally via Cache API
+        await engine.reload(req.payload.modelId);
+        
+        postMessage({ type: 'INIT_COMPLETE' } as WorkerResponse);
+        break;
+      }
+
+      case 'GENERATE': {
+        if (!engine) {
+          throw new Error('LLM Engine is not initialized. Please load a model first.');
+        }
+
+        // Web-LLM uses OpenAI-compatible Chat Completions API
+        const asyncChunkGenerator = await engine.chat.completions.create({
+          messages: [{ role: 'user', content: req.payload.prompt }],
+          stream: true,
+        });
+        
+        let fullText = '';
+        
+        for await (const chunk of asyncChunkGenerator) {
+          const token = chunk.choices[0]?.delta?.content || '';
+          fullText += token;
+          
+          postMessage({ 
+            type: 'GENERATE_TOKEN', 
+            payload: { token } 
+          } as WorkerResponse);
+        }
+
+        postMessage({ 
+          type: 'GENERATE_COMPLETE', 
+          payload: { fullText } 
+        } as WorkerResponse);
+        break;
+      }
+    }
+  } catch (err: any) {
+    const errorMsg = err.message || String(err);
+    if (req.type === 'INIT_MODEL') {
+      postMessage({ type: 'INIT_ERROR', error: errorMsg } as WorkerResponse);
+    } else if (req.type === 'GENERATE') {
+      postMessage({ type: 'GENERATE_ERROR', error: errorMsg } as WorkerResponse);
+    }
+  }
+};

--- a/src/scripts/ai/aiClient.ts
+++ b/src/scripts/ai/aiClient.ts
@@ -1,0 +1,103 @@
+import { SUPPORTED_MODELS } from './modelRegistry';
+import { checkWebGPUSupport } from './webgpuDetector';
+import { WorkerRequest, WorkerResponse, ProgressInfo, ModelMetadata } from './ai.types';
+import { createAIWorker } from './workerFactory';
+
+/**
+ * Singleton Client to be imported into React UI components.
+ * Offloads heavy LLM work to a background Web Worker.
+ */
+class AIClient {
+  private static instance: AIClient;
+  private worker: Worker | null = null;
+  
+  // Callbacks and promise handlers
+  private progressCallback: ((p: ProgressInfo) => void) | null = null;
+  private resolveInit: (() => void) | null = null;
+  private rejectInit: ((err: Error) => void) | null = null;
+  
+  private onTokenCallback: ((token: string) => void) | null = null;
+  private resolveGenerate: (() => void) | null = null;
+  private rejectGenerate: ((err: Error) => void) | null = null;
+
+  private constructor() {}
+
+  public static getInstance(): AIClient {
+    if (!AIClient.instance) {
+      AIClient.instance = new AIClient();
+    }
+    return AIClient.instance;
+  }
+
+  /** Lazy initialization of the Web Worker */
+  private initWorker() {
+    if (!this.worker) {
+      this.worker = createAIWorker();
+      this.worker.onmessage = this.handleWorkerMessage.bind(this);
+    }
+  }
+
+  private handleWorkerMessage(event: MessageEvent<WorkerResponse>) {
+    const res = event.data;
+    switch (res.type) {
+      case 'INIT_PROGRESS':
+        if (this.progressCallback) this.progressCallback(res.payload);
+        break;
+      case 'INIT_COMPLETE':
+        if (this.resolveInit) this.resolveInit();
+        break;
+      case 'INIT_ERROR':
+        if (this.rejectInit) this.rejectInit(new Error(res.error));
+        break;
+      case 'GENERATE_TOKEN':
+        if (this.onTokenCallback) this.onTokenCallback(res.payload.token);
+        break;
+      case 'GENERATE_COMPLETE':
+        if (this.resolveGenerate) this.resolveGenerate();
+        break;
+      case 'GENERATE_ERROR':
+        if (this.rejectGenerate) this.rejectGenerate(new Error(res.error));
+        break;
+    }
+  }
+
+  // --- Public API ---
+
+  public getAvailableModels(): ModelMetadata[] {
+    return SUPPORTED_MODELS;
+  }
+
+  public async checkSupport(): Promise<boolean> {
+    return await checkWebGPUSupport();
+  }
+
+  public onProgress(callback: (p: ProgressInfo) => void) {
+    this.progressCallback = callback;
+  }
+
+  public async selectModel(modelId: string): Promise<void> {
+    this.initWorker();
+    return new Promise((resolve, reject) => {
+      this.resolveInit = resolve;
+      this.rejectInit = reject;
+      
+      const req: WorkerRequest = { type: 'INIT_MODEL', payload: { modelId } };
+      this.worker!.postMessage(req);
+    });
+  }
+
+  public async generateResponse(prompt: string, onToken: (token: string) => void): Promise<void> {
+    this.initWorker();
+    this.onTokenCallback = onToken;
+    
+    return new Promise((resolve, reject) => {
+      this.resolveGenerate = resolve;
+      this.rejectGenerate = reject;
+      
+      const req: WorkerRequest = { type: 'GENERATE', payload: { prompt } };
+      this.worker!.postMessage(req);
+    });
+  }
+}
+
+export const aiClient = AIClient.getInstance();

--- a/src/scripts/ai/modelRegistry.ts
+++ b/src/scripts/ai/modelRegistry.ts
@@ -6,11 +6,6 @@ import { ModelMetadata } from './ai.types';
  */
 export const SUPPORTED_MODELS: ModelMetadata[] = [
   {
-    id: 'SmolLM2-135M-Instruct-q4f16_1-MLC',
-    friendlyName: 'SmolLM2 135M (Fastest, ~150MB)',
-    estimatedSize: '150MB'
-  },
-  {
     id: 'Llama-3.2-1B-Instruct-q4f16_1-MLC',
     friendlyName: 'Llama 3.2 1B (Balanced, ~800MB)',
     estimatedSize: '800MB'

--- a/src/scripts/ai/modelRegistry.ts
+++ b/src/scripts/ai/modelRegistry.ts
@@ -1,0 +1,23 @@
+import { ModelMetadata } from './ai.types';
+
+/**
+ * Standard list of officially optimized Web-LLM models.
+ * Find more at: https://github.com/mlc-ai/web-llm
+ */
+export const SUPPORTED_MODELS: ModelMetadata[] = [
+  {
+    id: 'SmolLM2-135M-Instruct-q4f16_1-MLC',
+    friendlyName: 'SmolLM2 135M (Fastest, ~150MB)',
+    estimatedSize: '150MB'
+  },
+  {
+    id: 'Llama-3.2-1B-Instruct-q4f16_1-MLC',
+    friendlyName: 'Llama 3.2 1B (Balanced, ~800MB)',
+    estimatedSize: '800MB'
+  },
+  {
+    id: 'Llama-3-8B-Instruct-q4f16_1-MLC',
+    friendlyName: 'Llama 3 8B (High Quality, ~5GB)',
+    estimatedSize: '5GB'
+  }
+];

--- a/src/scripts/ai/progressHandler.ts
+++ b/src/scripts/ai/progressHandler.ts
@@ -1,0 +1,11 @@
+import { ProgressInfo } from './ai.types';
+
+/**
+ * Maps the raw InitProgressReport from web-llm to our standard application structure.
+ */
+export function parseProgressMessage(text: string, progress: number): ProgressInfo {
+  return {
+    text,
+    progress: Math.max(0, Math.min(1, progress))
+  };
+}

--- a/src/scripts/ai/webgpuDetector.ts
+++ b/src/scripts/ai/webgpuDetector.ts
@@ -3,12 +3,12 @@
  * Note: Must be executed in a Window context (NewTab/Popup), not the Background Service Worker.
  */
 export async function checkWebGPUSupport(): Promise<boolean> {
-  if (!navigator.gpu) {
+  if (!navigator || !(navigator as any).gpu) {
     return false;
   }
   
   try {
-    const adapter = await navigator.gpu.requestAdapter();
+    const adapter = await (navigator as any).gpu.requestAdapter();
     return !!adapter;
   } catch (e) {
     console.warn('WebGPU request adapter failed:', e);

--- a/src/scripts/ai/webgpuDetector.ts
+++ b/src/scripts/ai/webgpuDetector.ts
@@ -1,0 +1,17 @@
+/**
+ * Detects if the current hardware and browser context support WebGPU.
+ * Note: Must be executed in a Window context (NewTab/Popup), not the Background Service Worker.
+ */
+export async function checkWebGPUSupport(): Promise<boolean> {
+  if (!navigator.gpu) {
+    return false;
+  }
+  
+  try {
+    const adapter = await navigator.gpu.requestAdapter();
+    return !!adapter;
+  } catch (e) {
+    console.warn('WebGPU request adapter failed:', e);
+    return false;
+  }
+}

--- a/src/scripts/ai/workerFactory.ts
+++ b/src/scripts/ai/workerFactory.ts
@@ -1,0 +1,3 @@
+export function createAIWorker(): Worker {
+  return new Worker(new URL('./ai.worker.ts', import.meta.url), { type: 'module' });
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -42,7 +42,8 @@ export default defineConfig({
         FAQs: resolve(__dirname, 'faqs.html'),  // Entry point for the Mindful landing page > FAQs page
         ManageAccount: resolve(__dirname, 'ManageAccount.html'),  // Entry point for Manage Account page
         NewTab: resolve(__dirname, 'NewTab.html'),  // Entry point for the new tab page
-        PopUp: resolve(__dirname, 'PopUp.html'),   // Entry point for the popup window
+        PopUp: resolve(__dirname, 'PopUp.html'),
+        Labs: resolve(__dirname, 'Labs.html'),   // Entry point for the popup window
       },
       output: {
         entryFileNames: '[name].js', // Maintain separate output files

--- a/vite.config.js
+++ b/vite.config.js
@@ -31,6 +31,9 @@ export default defineConfig({
       "@shared": fileURLToPath(new URL("./shared", import.meta.url)),
     },
   },
+  worker: {
+    format: "es",
+  },
   build: {
     rollupOptions: {
       input: {
@@ -51,7 +54,10 @@ export default defineConfig({
     emptyOutDir: true, // Clean the output directory before each build
     sourcemap: true,  // make runtime errors map to source
   },
-  esbuild: { // helps keep names visible in dev
+  esworker: {
+    format: "es",
+  },
+  build: { // helps keep names visible in dev
     keepNames: true,
   },
 });


### PR DESCRIPTION
We are using the `@mlc-ai/web-llm` package to download models and run them on the local GPU via WebGPU.

You can try out the local LLMs yourself at this link: https://chat.webllm.ai/, without building anything.

You can try this locally with `npm run dev`, and then visiting `/Labs.html`. If you begin chatting, a local model will be automatically downloaded and cached, and can then be run at reasonable speeds on your laptop.