### PR TITLE
feat: rate limiting for groupBookmarks endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,44 @@ This is all controlled by whatever file is named `amplify_outputs.json`.
 ### To work on sandbox
 1. Run `npx ampx sandbox` to have `amplify_outputs.json` generated for you.
 
+## How to test the sandbox groupBookmarks endpoint
+
+### API-level smoke test (rate limiting)
+Run `amplify/tools/test_group_bookmarks.sh` from any directory — it reads the endpoint automatically from `amplify_outputs.sandbox.json` (falling back to `amplify_outputs.json`).
+
+```
+bash amplify/tools/test_group_bookmarks.sh
+```
+
+Calls 1–10 should return `200`; calls 11–12 should return `429`.
+
+### End-to-end test via the Chrome extension
+The extension normally calls the production API. To point it at your sandbox for local testing, make the following **temporary, local-only** changes (do not commit them):
+
+**1. `src/scripts/import/groupingLLMRemote.ts`** — replace the `API_BASE_URL` constant with your sandbox endpoint:
+```ts
+// Get the endpoint from amplify_outputs.sandbox.json → custom.API.bookmarks.endpoint
+const API_BASE_URL = "https://<your-sandbox-id>.execute-api.us-west-1.amazonaws.com";
+```
+
+**2. `public/manifest.json`** — add the sandbox API Gateway domain to `optional_host_permissions` and `content_security_policy.extension_pages`:
+```json
+"optional_host_permissions": [
+  "https://api.mindfulbookmarks.com/*",
+  "https://*.execute-api.us-west-1.amazonaws.com/*",
+  ...
+],
+"content_security_policy": {
+  "extension_pages": "script-src 'self'; object-src 'self'; connect-src 'self' ... https://*.execute-api.us-west-1.amazonaws.com https://app.posthog.com;"
+}
+```
+
+**3. Rebuild and reload:**
+```
+npm run build
+```
+Then reload the unpacked extension in `chrome://extensions`.
+
 ## How to cut a new release for the Chrome Extensions store
 ```
 # cut release

--- a/amplify/backend.ts
+++ b/amplify/backend.ts
@@ -61,8 +61,12 @@ kmsKey.grant(loadBookmarksFn, 'kms:Decrypt');
  * Tracks per-IP call counts for the groupBookmarks endpoint.
  * Each item is keyed by "rl#<ip>#<window>" and has a TTL so rows
  * are automatically cleaned up after the window expires.
+ *
+ * Must be created in the groupBookmarks function's own nested stack to avoid
+ * cross-nested-stack reference issues that prevent the env var from resolving
+ * in Amplify sandbox/deployments.
  */
-const rateLimitTable = new dynamodb.Table(stack, 'GroupBookmarksRateLimit', {
+const rateLimitTable = new dynamodb.Table(groupBookmarksFn.stack, 'GroupBookmarksRateLimit', {
   partitionKey: { name: 'pk', type: dynamodb.AttributeType.STRING },
   billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
   timeToLiveAttribute: 'ttl',

--- a/amplify/backend.ts
+++ b/amplify/backend.ts
@@ -1,5 +1,7 @@
 /* -------------------- Imports -------------------- */
 import { defineBackend } from '@aws-amplify/backend';
+import { RemovalPolicy } from 'aws-cdk-lib';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as apigwv2 from 'aws-cdk-lib/aws-apigatewayv2';
 import * as kms from 'aws-cdk-lib/aws-kms';
@@ -52,6 +54,22 @@ const kmsKey = kms.Key.fromKeyArn(stack, 'BookmarksKmsKey', kmsKeyId);
 // Grant only what each function needs
 kmsKey.grant(saveBookmarksFn, 'kms:GenerateDataKey');
 kmsKey.grant(loadBookmarksFn, 'kms:Decrypt');
+/* ---------------------------------------------------------- */
+
+/* -------------------- DynamoDB rate-limit table -------------------- */
+/**
+ * Tracks per-IP call counts for the groupBookmarks endpoint.
+ * Each item is keyed by "rl#<ip>#<window>" and has a TTL so rows
+ * are automatically cleaned up after the window expires.
+ */
+const rateLimitTable = new dynamodb.Table(stack, 'GroupBookmarksRateLimit', {
+  partitionKey: { name: 'pk', type: dynamodb.AttributeType.STRING },
+  billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+  timeToLiveAttribute: 'ttl',
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+rateLimitTable.grantReadWriteData(groupBookmarksFn);
+groupBookmarksFn.addEnvironment('RATE_LIMIT_TABLE', rateLimitTable.tableName);
 /* ---------------------------------------------------------- */
 
 /* -------------------- Lambda environment -------------------- */
@@ -160,6 +178,16 @@ api.addRoutes({
   integration: new HttpLambdaIntegration('groupBookmarksIntegration', groupBookmarksFn),
   // No authorizer: public endpoint, safe because it only writes to OpenAI and returns JSON
 });
+
+// Stage-level throttle: guards the whole API against flood/abuse.
+// Per-IP rate limiting is enforced inside the Lambda via DynamoDB.
+const cfnStage = api.defaultStage?.node.defaultChild as apigwv2.CfnStage;
+if (cfnStage) {
+  cfnStage.defaultRouteSettings = {
+    throttlingBurstLimit: 30,  // max concurrent in-flight requests
+    throttlingRateLimit: 10,   // sustained requests/second across all callers
+  };
+}
 /* ---------------------------------------------------------- */
 
 /* -------------------- Lambda IAM for S3 + KMS -------------------- */

--- a/amplify/functions/_shared/safe.ts
+++ b/amplify/functions/_shared/safe.ts
@@ -6,8 +6,9 @@ export const withCorsAndErrors = (
   inner: (event: any, cors: ReturnType<typeof evalCors>) => Promise<any>
 ) => {
   return async (event: any) => {
+    let cors: ReturnType<typeof evalCors> | undefined;
     try {
-      const cors = evalCors(event);
+      cors = evalCors(event);
       const pre = preflightIfNeeded(cors);   if (pre)  return pre;
       const ban = assertCorsOr403(cors);     if (ban)  return ban;
 
@@ -15,12 +16,15 @@ export const withCorsAndErrors = (
       // pass-through full responses; otherwise wrap as 200 in your inner
       return out;
     } catch (err: any) {
-      // We may not have cors if evalCors itself failed; use best-effort headers
-      const headers = {
-        "Content-Type": "application/json",
-        "Access-Control-Allow-Origin": process.env.ALLOWED_ORIGIN || "*",
-        "Access-Control-Allow-Credentials": "true",
-      };
+      // Reuse the per-request CORS headers when available so error responses
+      // carry the correct Allow-Origin for this caller's origin.
+      // Fall back to best-effort headers only if evalCors itself threw.
+      const headers = cors
+        ? cors.headers
+        : {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": process.env.ALLOWED_ORIGIN || "*",
+          };
 
       if (err instanceof HttpError) {
         console.error("[HttpError]", { statusCode: err.statusCode, message: err.message, details: err.details });

--- a/amplify/functions/groupBookmarks/handler.ts
+++ b/amplify/functions/groupBookmarks/handler.ts
@@ -1,12 +1,13 @@
 /* -------------------- Imports -------------------- */
 import type { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { DynamoDBClient, UpdateItemCommand } from "@aws-sdk/client-dynamodb";
 import OpenAI from "openai";
 
 /* Shared Amplify helpers */
 import { withCorsAndErrors } from "../_shared/safe";
 import { resp } from "../_shared/http";
 import { evalCors } from "../_shared/cors"; // CorsPack type only
-import { badRequest, serverError } from "../_shared/errors";
+import { badRequest, serverError, tooMany } from "../_shared/errors";
 
 /* Constants */
 import { PurposeId } from "@shared/constants/purposeId";
@@ -37,6 +38,13 @@ if (!apiKey) {
   throw new Error("OPENAI_API_KEY env var is missing at runtime");
 }
 const openai = new OpenAI({ apiKey });
+/* ---------------------------------------------------------- */
+
+/* -------------------- Rate-limit config -------------------- */
+const dynamo = new DynamoDBClient({});
+const RATE_LIMIT_TABLE = process.env.RATE_LIMIT_TABLE;
+const RATE_WINDOW_SEC = 600;  // 10-minute rolling window
+const RATE_LIMIT_MAX = 5;     // max AI Organize calls per IP per window
 /* ---------------------------------------------------------- */
 
 /* -------------------- Helper functions -------------------- */
@@ -164,6 +172,32 @@ const groupBookmarksCore = async (
   event: APIGatewayProxyEvent,
   cors: ReturnType<typeof evalCors>
 ): Promise<APIGatewayProxyResult> => {
+  // Per-IP rate limiting: 5 calls per 10-minute window, tracked in DynamoDB
+  if (RATE_LIMIT_TABLE) {
+    // HTTP API v2 puts the IP at requestContext.http.sourceIp; v1 uses identity.sourceIp
+    const ip = (event as any).requestContext?.http?.sourceIp
+      ?? event.requestContext?.identity?.sourceIp
+      ?? "unknown";
+    const window = Math.floor(Date.now() / 1000 / RATE_WINDOW_SEC);
+    const pk = `rl#${ip}#${window}`;
+
+    const res = await dynamo.send(new UpdateItemCommand({
+      TableName: RATE_LIMIT_TABLE,
+      Key: { pk: { S: pk } },
+      UpdateExpression: "ADD #n :one SET #ttl = if_not_exists(#ttl, :exp)",
+      ExpressionAttributeNames: { "#n": "n", "#ttl": "ttl" },
+      ExpressionAttributeValues: {
+        ":one": { N: "1" },
+        ":exp": { N: String((window + 1) * RATE_WINDOW_SEC) },
+      },
+      ReturnValues: "UPDATED_NEW",
+    }));
+
+    if (Number(res.Attributes?.n?.N) > RATE_LIMIT_MAX) {
+      throw tooMany("Rate limit exceeded — please wait before using AI Organize again.");
+    }
+  }
+
   if (!event.body) throw badRequest("Missing body");
 
   const rawBody = event.isBase64Encoded

--- a/amplify/functions/groupBookmarks/handler.ts
+++ b/amplify/functions/groupBookmarks/handler.ts
@@ -44,7 +44,7 @@ const openai = new OpenAI({ apiKey });
 const dynamo = new DynamoDBClient({});
 const RATE_LIMIT_TABLE = process.env.RATE_LIMIT_TABLE;
 const RATE_WINDOW_SEC = 600;  // 10-minute rolling window
-const RATE_LIMIT_MAX = 5;     // max AI Organize calls per IP per window
+const RATE_LIMIT_MAX = 10;    // max AI Organize calls per IP per window
 /* ---------------------------------------------------------- */
 
 /* -------------------- Helper functions -------------------- */

--- a/amplify/tools/test_group_bookmarks.sh
+++ b/amplify/tools/test_group_bookmarks.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ENDPOINT=$(node -e "const o=require('$ROOT/amplify_outputs.sandbox.json');console.log(o.custom.API.bookmarks.endpoint)" 2>/dev/null \
+  || node -e "const o=require('$ROOT/amplify_outputs.json');console.log(o.custom.API.bookmarks.endpoint)")
+URL="${ENDPOINT}/groupBookmarks"
+BODY='{"items":[{"id":"1","url":"https://example.com","title":"Test"}],"purposes":["personal"]}'
+
+for i in $(seq 1 12); do
+  curl -s -o /dev/null -w "Call $i: %{http_code}\n" -X POST "$URL" -H "Content-Type: application/json" -d "$BODY"
+done

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"@aws-amplify/cli": "^14.0.0",
 				"@aws-amplify/storage": "^6.9.4",
 				"@aws-amplify/ui-react": "^6.11.2",
+				"@aws-sdk/client-dynamodb": "^3.1034.0",
 				"@aws-sdk/client-kms": "^3.864.0",
 				"@aws-sdk/client-s3": "^3.864.0",
 				"@aws-sdk/client-sesv2": "^3.936.0",
@@ -18119,6 +18120,592 @@
 				"node": ">=18.0.0"
 			}
 		},
+		"node_modules/@aws-sdk/client-dynamodb": {
+			"version": "3.1034.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1034.0.tgz",
+			"integrity": "sha512-lhu6Aada1Fgg5RCc9IMmiLkV4nGeDKq4z0BF9mXzA37OX4ad/mWMGTofqdJvY80Gx2714jY5yiEHAlyIN2PL8w==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "^3.974.3",
+				"@aws-sdk/credential-provider-node": "^3.972.34",
+				"@aws-sdk/dynamodb-codec": "^3.973.3",
+				"@aws-sdk/middleware-endpoint-discovery": "^3.972.11",
+				"@aws-sdk/middleware-host-header": "^3.972.10",
+				"@aws-sdk/middleware-logger": "^3.972.10",
+				"@aws-sdk/middleware-recursion-detection": "^3.972.11",
+				"@aws-sdk/middleware-user-agent": "^3.972.33",
+				"@aws-sdk/region-config-resolver": "^3.972.13",
+				"@aws-sdk/types": "^3.973.8",
+				"@aws-sdk/util-endpoints": "^3.996.8",
+				"@aws-sdk/util-user-agent-browser": "^3.972.10",
+				"@aws-sdk/util-user-agent-node": "^3.973.19",
+				"@smithy/config-resolver": "^4.4.17",
+				"@smithy/core": "^3.23.16",
+				"@smithy/fetch-http-handler": "^5.3.17",
+				"@smithy/hash-node": "^4.2.14",
+				"@smithy/invalid-dependency": "^4.2.14",
+				"@smithy/middleware-content-length": "^4.2.14",
+				"@smithy/middleware-endpoint": "^4.4.31",
+				"@smithy/middleware-retry": "^4.5.4",
+				"@smithy/middleware-serde": "^4.2.19",
+				"@smithy/middleware-stack": "^4.2.14",
+				"@smithy/node-config-provider": "^4.3.14",
+				"@smithy/node-http-handler": "^4.6.0",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/smithy-client": "^4.12.12",
+				"@smithy/types": "^4.14.1",
+				"@smithy/url-parser": "^4.2.14",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-body-length-browser": "^4.2.2",
+				"@smithy/util-body-length-node": "^4.2.3",
+				"@smithy/util-defaults-mode-browser": "^4.3.48",
+				"@smithy/util-defaults-mode-node": "^4.2.53",
+				"@smithy/util-endpoints": "^3.4.2",
+				"@smithy/util-middleware": "^4.2.14",
+				"@smithy/util-retry": "^4.3.3",
+				"@smithy/util-utf8": "^4.2.2",
+				"@smithy/util-waiter": "^4.2.16",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/core": {
+			"version": "3.974.3",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.3.tgz",
+			"integrity": "sha512-W3aJJm2clu8OmsrwMOMnfof13O6LGnbknnZIQeSRbxjqKah2nVvkjbUBBZVhWrt08KC69H7WsINTdrxC/2SXQw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@aws-sdk/xml-builder": "^3.972.18",
+				"@smithy/core": "^3.23.16",
+				"@smithy/node-config-provider": "^4.3.14",
+				"@smithy/property-provider": "^4.2.14",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/signature-v4": "^5.3.14",
+				"@smithy/smithy-client": "^4.12.12",
+				"@smithy/types": "^4.14.1",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-middleware": "^4.2.14",
+				"@smithy/util-retry": "^4.3.3",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.972.29",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.29.tgz",
+			"integrity": "sha512-rf+AlUxgTeSzQ/4zoS0D+Bt7XvgpY48PnWG8Yg/N9fdMgyK2Jaqa+6tLZp4MYMIMHkGrfAxnbSeb2YLMGFMg6g==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.3",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/property-provider": "^4.2.14",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.972.31",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.31.tgz",
+			"integrity": "sha512-TR2/lQ3qKFj2EOrsiASzemsNEz2uzZ/SUBf48+U4Cr9a/FZlHfH/hwAeBJNBp1gMyJNxROJZhT3dn1cO+jnYfQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.3",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/fetch-http-handler": "^5.3.17",
+				"@smithy/node-http-handler": "^4.6.0",
+				"@smithy/property-provider": "^4.2.14",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/smithy-client": "^4.12.12",
+				"@smithy/types": "^4.14.1",
+				"@smithy/util-stream": "^4.5.24",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.972.33",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.33.tgz",
+			"integrity": "sha512-UwdbJbOrgnOxZbshaNZ4DzX35h5wQd33MNYTGzWhN3ORG9lG9KQbDX6l6tDJSAdaGTktJoZPSritmUoW1rYkRA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.3",
+				"@aws-sdk/credential-provider-env": "^3.972.29",
+				"@aws-sdk/credential-provider-http": "^3.972.31",
+				"@aws-sdk/credential-provider-login": "^3.972.33",
+				"@aws-sdk/credential-provider-process": "^3.972.29",
+				"@aws-sdk/credential-provider-sso": "^3.972.33",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.33",
+				"@aws-sdk/nested-clients": "^3.997.1",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/credential-provider-imds": "^4.2.14",
+				"@smithy/property-provider": "^4.2.14",
+				"@smithy/shared-ini-file-loader": "^4.4.9",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-login": {
+			"version": "3.972.33",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.33.tgz",
+			"integrity": "sha512-WyZuPVoDM1HGNl41eVg8HSSXIB+FGkuuK63GhDbh4TMdfWU03AciWvF/QqOVWvJtWVYaLddANJ+aUklVr2ieuw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.3",
+				"@aws-sdk/nested-clients": "^3.997.1",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/property-provider": "^4.2.14",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/shared-ini-file-loader": "^4.4.9",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.972.34",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.34.tgz",
+			"integrity": "sha512-sPcisURibKU4x0PCWJkWF1KJYm49Cph9dCn/PAnG5FU0wq5Id3g2v7RuEWAtNlKv1Af4gUJYBVGOeNpSEEx41A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "^3.972.29",
+				"@aws-sdk/credential-provider-http": "^3.972.31",
+				"@aws-sdk/credential-provider-ini": "^3.972.33",
+				"@aws-sdk/credential-provider-process": "^3.972.29",
+				"@aws-sdk/credential-provider-sso": "^3.972.33",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.33",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/credential-provider-imds": "^4.2.14",
+				"@smithy/property-provider": "^4.2.14",
+				"@smithy/shared-ini-file-loader": "^4.4.9",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.972.29",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.29.tgz",
+			"integrity": "sha512-DURisqWS3bUgiwMXTmzymVNGlcRW0FnbPZ3SZknhmxnCXm3n9idkTJ6T+Uir359KRKtJNFLRViskk8HsSVLi1w==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.3",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/property-provider": "^4.2.14",
+				"@smithy/shared-ini-file-loader": "^4.4.9",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.972.33",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.33.tgz",
+			"integrity": "sha512-9y9obU4IQWru9f+NiiscUeyCe5ZmQav4FKEb1qfUNrik/C3BzBGUnHQWyPEyXjOX9cb+vx1TYx0qZBtinKdzTA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.3",
+				"@aws-sdk/nested-clients": "^3.997.1",
+				"@aws-sdk/token-providers": "3.1034.0",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/property-provider": "^4.2.14",
+				"@smithy/shared-ini-file-loader": "^4.4.9",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.972.33",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.33.tgz",
+			"integrity": "sha512-RazhlN0YAkna2T2p2v4YuuRlVBVRNo8V0SL+9JePTWDndEUAeOBAjYeQfAMbtDyCh120+zA0Op6V0jS4dw2+iw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.3",
+				"@aws-sdk/nested-clients": "^3.997.1",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/property-provider": "^4.2.14",
+				"@smithy/shared-ini-file-loader": "^4.4.9",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-host-header": {
+			"version": "3.972.10",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
+			"integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-logger": {
+			"version": "3.972.10",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
+			"integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-recursion-detection": {
+			"version": "3.972.11",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
+			"integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@aws/lambda-invoke-store": "^0.2.2",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-sdk-s3": {
+			"version": "3.972.32",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.32.tgz",
+			"integrity": "sha512-dc2O2x0V5pGJhmdQYQveUIFtMZsur7GrGuSgoKM4oQJuEcfvwnJ3sj+ip6WnxR5l6TrX5zkl4KgcgswOy3wAzQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.3",
+				"@aws-sdk/types": "^3.973.8",
+				"@aws-sdk/util-arn-parser": "^3.972.3",
+				"@smithy/core": "^3.23.16",
+				"@smithy/node-config-provider": "^4.3.14",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/signature-v4": "^5.3.14",
+				"@smithy/smithy-client": "^4.12.12",
+				"@smithy/types": "^4.14.1",
+				"@smithy/util-config-provider": "^4.2.2",
+				"@smithy/util-middleware": "^4.2.14",
+				"@smithy/util-stream": "^4.5.24",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-user-agent": {
+			"version": "3.972.33",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.33.tgz",
+			"integrity": "sha512-mqtT3Fo7xanWMk2SbAcKLGGI/q1GHWNrExBj7cnWP2W2mkTMheXB4ntJvwPZ1UxPrQobrsv2dWFXmaOJeSOiDg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.3",
+				"@aws-sdk/types": "^3.973.8",
+				"@aws-sdk/util-endpoints": "^3.996.8",
+				"@smithy/core": "^3.23.16",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/types": "^4.14.1",
+				"@smithy/util-retry": "^4.3.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/nested-clients": {
+			"version": "3.997.1",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.1.tgz",
+			"integrity": "sha512-Afc9hc2WZs3X4Jb8dnxyuYiZsLoWRO51roTCRf497gPnAKN2WRdXANu1vaVCTzwnDMOYFXb/cYv4ZSjxqAqcKA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "^3.974.3",
+				"@aws-sdk/middleware-host-header": "^3.972.10",
+				"@aws-sdk/middleware-logger": "^3.972.10",
+				"@aws-sdk/middleware-recursion-detection": "^3.972.11",
+				"@aws-sdk/middleware-user-agent": "^3.972.33",
+				"@aws-sdk/region-config-resolver": "^3.972.13",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.20",
+				"@aws-sdk/types": "^3.973.8",
+				"@aws-sdk/util-endpoints": "^3.996.8",
+				"@aws-sdk/util-user-agent-browser": "^3.972.10",
+				"@aws-sdk/util-user-agent-node": "^3.973.19",
+				"@smithy/config-resolver": "^4.4.17",
+				"@smithy/core": "^3.23.16",
+				"@smithy/fetch-http-handler": "^5.3.17",
+				"@smithy/hash-node": "^4.2.14",
+				"@smithy/invalid-dependency": "^4.2.14",
+				"@smithy/middleware-content-length": "^4.2.14",
+				"@smithy/middleware-endpoint": "^4.4.31",
+				"@smithy/middleware-retry": "^4.5.4",
+				"@smithy/middleware-serde": "^4.2.19",
+				"@smithy/middleware-stack": "^4.2.14",
+				"@smithy/node-config-provider": "^4.3.14",
+				"@smithy/node-http-handler": "^4.6.0",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/smithy-client": "^4.12.12",
+				"@smithy/types": "^4.14.1",
+				"@smithy/url-parser": "^4.2.14",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-body-length-browser": "^4.2.2",
+				"@smithy/util-body-length-node": "^4.2.3",
+				"@smithy/util-defaults-mode-browser": "^4.3.48",
+				"@smithy/util-defaults-mode-node": "^4.2.53",
+				"@smithy/util-endpoints": "^3.4.2",
+				"@smithy/util-middleware": "^4.2.14",
+				"@smithy/util-retry": "^4.3.3",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/region-config-resolver": {
+			"version": "3.972.13",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
+			"integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/config-resolver": "^4.4.17",
+				"@smithy/node-config-provider": "^4.3.14",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/signature-v4-multi-region": {
+			"version": "3.996.20",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.20.tgz",
+			"integrity": "sha512-MEj6DhEcaO8RgVtFCJ+xpCQnZC3Iesr09avdY75qkMQfckQULu447IegK7Rs1MCGerVBfKnJQ4q+pQq9hI5lng==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/middleware-sdk-s3": "^3.972.32",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/signature-v4": "^5.3.14",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/token-providers": {
+			"version": "3.1034.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1034.0.tgz",
+			"integrity": "sha512-8E+KGcD4ET0H9FXJ2/ZWbfFnQNYEkTZZYJxAs1lkdJlve1AYuqaydInIFfvNgoz5GbYtzbK8/ugsSMu5wPm6kA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.3",
+				"@aws-sdk/nested-clients": "^3.997.1",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/property-provider": "^4.2.14",
+				"@smithy/shared-ini-file-loader": "^4.4.9",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/types": {
+			"version": "3.973.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+			"integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-arn-parser": {
+			"version": "3.972.3",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
+			"integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-endpoints": {
+			"version": "3.996.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
+			"integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/types": "^4.14.1",
+				"@smithy/url-parser": "^4.2.14",
+				"@smithy/util-endpoints": "^3.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-user-agent-browser": {
+			"version": "3.972.10",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
+			"integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/types": "^4.14.1",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-user-agent-node": {
+			"version": "3.973.19",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.19.tgz",
+			"integrity": "sha512-ZAfHjpzdbrzkAftC139JoYGfXzDh5HY+AxRzw8pGJ8cULsf+l721sKAMK8mV5NvRETaW/BwghSwQhGgoNgrxMw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/middleware-user-agent": "^3.972.33",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/node-config-provider": "^4.3.14",
+				"@smithy/types": "^4.14.1",
+				"@smithy/util-config-provider": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"peerDependencies": {
+				"aws-crt": ">=1.0.0"
+			},
+			"peerDependenciesMeta": {
+				"aws-crt": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/xml-builder": {
+			"version": "3.972.18",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.18.tgz",
+			"integrity": "sha512-BMDNVG1ETXRhl1tnisQiYBef3RShJ1kfZA7x7afivTFMLirfHNTb6U71K569HNXhSXbQZsweHvSDZ6euBw8hPA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.14.1",
+				"fast-xml-parser": "5.5.8",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-dynamodb/node_modules/@aws/lambda-invoke-store": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+			"integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/util-base64": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+			"integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/util-utf8": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+			"integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-dynamodb/node_modules/fast-xml-parser": {
+			"version": "5.5.8",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+			"integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"fast-xml-builder": "^1.1.4",
+				"path-expression-matcher": "^1.2.0",
+				"strnum": "^2.2.0"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
+		},
+		"node_modules/@aws-sdk/client-dynamodb/node_modules/strnum": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+			"integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/@aws-sdk/client-ec2": {
 			"version": "3.624.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.624.0.tgz",
@@ -27939,6 +28526,133 @@
 				"node": ">=18.0.0"
 			}
 		},
+		"node_modules/@aws-sdk/dynamodb-codec": {
+			"version": "3.973.3",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.3.tgz",
+			"integrity": "sha512-MRe24Bbf5a6CY3gJx8/E8IChYaNfpkCWBYJAtDbB7bN98+r2YI5pqVate8nKyxy1Abgr/uiLjWirbb/KhequIA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.3",
+				"@smithy/core": "^3.23.16",
+				"@smithy/types": "^4.14.1",
+				"@smithy/util-base64": "^4.3.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/dynamodb-codec/node_modules/@aws-sdk/core": {
+			"version": "3.974.3",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.3.tgz",
+			"integrity": "sha512-W3aJJm2clu8OmsrwMOMnfof13O6LGnbknnZIQeSRbxjqKah2nVvkjbUBBZVhWrt08KC69H7WsINTdrxC/2SXQw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@aws-sdk/xml-builder": "^3.972.18",
+				"@smithy/core": "^3.23.16",
+				"@smithy/node-config-provider": "^4.3.14",
+				"@smithy/property-provider": "^4.2.14",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/signature-v4": "^5.3.14",
+				"@smithy/smithy-client": "^4.12.12",
+				"@smithy/types": "^4.14.1",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-middleware": "^4.2.14",
+				"@smithy/util-retry": "^4.3.3",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/dynamodb-codec/node_modules/@aws-sdk/types": {
+			"version": "3.973.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+			"integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/dynamodb-codec/node_modules/@aws-sdk/xml-builder": {
+			"version": "3.972.18",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.18.tgz",
+			"integrity": "sha512-BMDNVG1ETXRhl1tnisQiYBef3RShJ1kfZA7x7afivTFMLirfHNTb6U71K569HNXhSXbQZsweHvSDZ6euBw8hPA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.14.1",
+				"fast-xml-parser": "5.5.8",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/dynamodb-codec/node_modules/@smithy/util-base64": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+			"integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/dynamodb-codec/node_modules/@smithy/util-utf8": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+			"integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/dynamodb-codec/node_modules/fast-xml-parser": {
+			"version": "5.5.8",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+			"integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"fast-xml-builder": "^1.1.4",
+				"path-expression-matcher": "^1.2.0",
+				"strnum": "^2.2.0"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
+		},
+		"node_modules/@aws-sdk/dynamodb-codec/node_modules/strnum": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+			"integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/@aws-sdk/ec2-metadata-service": {
 			"version": "3.916.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/ec2-metadata-service/-/ec2-metadata-service-3.916.0.tgz",
@@ -27956,6 +28670,19 @@
 			},
 			"engines": {
 				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/endpoint-cache": {
+			"version": "3.972.5",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.5.tgz",
+			"integrity": "sha512-itVdge0NozgtgmtbZ25FVwWU3vGlE7x7feE/aOEJNkQfEpbkrF8Rj1QmnK+2blFfYE1xWt/iU+6/jUp/pv1+MA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"mnemonist": "0.38.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
 			}
 		},
 		"node_modules/@aws-sdk/eventstream-handler-node": {
@@ -28037,6 +28764,36 @@
 			},
 			"engines": {
 				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-endpoint-discovery": {
+			"version": "3.972.11",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.11.tgz",
+			"integrity": "sha512-vXARCZVFQHdsd6qPPZyC/hh+5x2XsCYKqUQDCqnUlpGpChMpDojOOacQWdLJ+FFXKN8X3cmLOGrtgx/zysCKqQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/endpoint-cache": "^3.972.5",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/node-config-provider": "^4.3.14",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-endpoint-discovery/node_modules/@aws-sdk/types": {
+			"version": "3.973.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+			"integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
 			}
 		},
 		"node_modules/@aws-sdk/middleware-eventstream": {
@@ -35908,6 +36665,7 @@
 			"version": "4.2.5",
 			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.5.tgz",
 			"integrity": "sha512-j7HwVkBw68YW8UmFRcjZOmssE77Rvk0GWAIN1oFBhsaovQmZWYCIcGa9/pwRB0ExI8Sk9MWNALTjftjHZea7VA==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.9.0",
@@ -35970,16 +36728,16 @@
 			}
 		},
 		"node_modules/@smithy/config-resolver": {
-			"version": "4.4.3",
-			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.3.tgz",
-			"integrity": "sha512-ezHLe1tKLUxDJo2LHtDuEDyWXolw8WGOR92qb4bQdWq/zKenO5BvctZGrVJBK08zjezSk7bmbKFOXIVyChvDLw==",
+			"version": "4.4.17",
+			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.17.tgz",
+			"integrity": "sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/node-config-provider": "^4.3.5",
-				"@smithy/types": "^4.9.0",
-				"@smithy/util-config-provider": "^4.2.0",
-				"@smithy/util-endpoints": "^3.2.5",
-				"@smithy/util-middleware": "^4.2.5",
+				"@smithy/node-config-provider": "^4.3.14",
+				"@smithy/types": "^4.14.1",
+				"@smithy/util-config-provider": "^4.2.2",
+				"@smithy/util-endpoints": "^3.4.2",
+				"@smithy/util-middleware": "^4.2.14",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -35987,20 +36745,20 @@
 			}
 		},
 		"node_modules/@smithy/core": {
-			"version": "3.18.5",
-			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.18.5.tgz",
-			"integrity": "sha512-6gnIz3h+PEPQGDj8MnRSjDvKBah042jEoPgjFGJ4iJLBE78L4lY/n98x14XyPF4u3lN179Ub/ZKFY5za9GeLQw==",
+			"version": "3.23.16",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.16.tgz",
+			"integrity": "sha512-JStomOrINQA1VqNEopLsgcdgwd42au7mykKqVr30XFw89wLt9sDxJDi4djVPRwQmmzyTGy/uOvTc2ultMpFi1w==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/middleware-serde": "^4.2.6",
-				"@smithy/protocol-http": "^5.3.5",
-				"@smithy/types": "^4.9.0",
-				"@smithy/util-base64": "^4.3.0",
-				"@smithy/util-body-length-browser": "^4.2.0",
-				"@smithy/util-middleware": "^4.2.5",
-				"@smithy/util-stream": "^4.5.6",
-				"@smithy/util-utf8": "^4.2.0",
-				"@smithy/uuid": "^1.1.0",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/types": "^4.14.1",
+				"@smithy/url-parser": "^4.2.14",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-body-length-browser": "^4.2.2",
+				"@smithy/util-middleware": "^4.2.14",
+				"@smithy/util-stream": "^4.5.24",
+				"@smithy/util-utf8": "^4.2.2",
+				"@smithy/uuid": "^1.1.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -36008,13 +36766,13 @@
 			}
 		},
 		"node_modules/@smithy/core/node_modules/@smithy/util-base64": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
-			"integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+			"integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/util-buffer-from": "^4.2.0",
-				"@smithy/util-utf8": "^4.2.0",
+				"@smithy/util-buffer-from": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -36022,12 +36780,12 @@
 			}
 		},
 		"node_modules/@smithy/core/node_modules/@smithy/util-utf8": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-			"integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+			"integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/util-buffer-from": "^4.2.0",
+				"@smithy/util-buffer-from": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -36035,15 +36793,15 @@
 			}
 		},
 		"node_modules/@smithy/credential-provider-imds": {
-			"version": "4.2.5",
-			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.5.tgz",
-			"integrity": "sha512-BZwotjoZWn9+36nimwm/OLIcVe+KYRwzMjfhd4QT7QxPm9WY0HiOV8t/Wlh+HVUif0SBVV7ksq8//hPaBC/okQ==",
+			"version": "4.2.14",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
+			"integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/node-config-provider": "^4.3.5",
-				"@smithy/property-provider": "^4.2.5",
-				"@smithy/types": "^4.9.0",
-				"@smithy/url-parser": "^4.2.5",
+				"@smithy/node-config-provider": "^4.3.14",
+				"@smithy/property-provider": "^4.2.14",
+				"@smithy/types": "^4.14.1",
+				"@smithy/url-parser": "^4.2.14",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -36133,15 +36891,15 @@
 			}
 		},
 		"node_modules/@smithy/fetch-http-handler": {
-			"version": "5.3.6",
-			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.6.tgz",
-			"integrity": "sha512-3+RG3EA6BBJ/ofZUeTFJA7mHfSYrZtQIrDP9dI8Lf7X6Jbos2jptuLrAAteDiFVrmbEmLSuRG/bUKzfAXk7dhg==",
+			"version": "5.3.17",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
+			"integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/protocol-http": "^5.3.5",
-				"@smithy/querystring-builder": "^4.2.5",
-				"@smithy/types": "^4.9.0",
-				"@smithy/util-base64": "^4.3.0",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/querystring-builder": "^4.2.14",
+				"@smithy/types": "^4.14.1",
+				"@smithy/util-base64": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -36149,13 +36907,13 @@
 			}
 		},
 		"node_modules/@smithy/fetch-http-handler/node_modules/@smithy/querystring-builder": {
-			"version": "4.2.5",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.5.tgz",
-			"integrity": "sha512-y98otMI1saoajeik2kLfGyRp11e5U/iJYH/wLCh3aTV/XutbGT9nziKGkgCaMD1ghK7p6htHMm6b6scl9JRUWg==",
+			"version": "4.2.14",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
+			"integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.9.0",
-				"@smithy/util-uri-escape": "^4.2.0",
+				"@smithy/types": "^4.14.1",
+				"@smithy/util-uri-escape": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -36163,13 +36921,13 @@
 			}
 		},
 		"node_modules/@smithy/fetch-http-handler/node_modules/@smithy/util-base64": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
-			"integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+			"integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/util-buffer-from": "^4.2.0",
-				"@smithy/util-utf8": "^4.2.0",
+				"@smithy/util-buffer-from": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -36177,9 +36935,9 @@
 			}
 		},
 		"node_modules/@smithy/fetch-http-handler/node_modules/@smithy/util-uri-escape": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-			"integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+			"integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -36189,12 +36947,12 @@
 			}
 		},
 		"node_modules/@smithy/fetch-http-handler/node_modules/@smithy/util-utf8": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-			"integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+			"integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/util-buffer-from": "^4.2.0",
+				"@smithy/util-buffer-from": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -36217,14 +36975,14 @@
 			}
 		},
 		"node_modules/@smithy/hash-node": {
-			"version": "4.2.5",
-			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.5.tgz",
-			"integrity": "sha512-DpYX914YOfA3UDT9CN1BM787PcHfWRBB43fFGCYrZFUH0Jv+5t8yYl+Pd5PW4+QzoGEDvn5d5QIO4j2HyYZQSA==",
+			"version": "4.2.14",
+			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
+			"integrity": "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.9.0",
-				"@smithy/util-buffer-from": "^4.2.0",
-				"@smithy/util-utf8": "^4.2.0",
+				"@smithy/types": "^4.14.1",
+				"@smithy/util-buffer-from": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -36232,12 +36990,12 @@
 			}
 		},
 		"node_modules/@smithy/hash-node/node_modules/@smithy/util-utf8": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-			"integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+			"integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/util-buffer-from": "^4.2.0",
+				"@smithy/util-buffer-from": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -36272,12 +37030,12 @@
 			}
 		},
 		"node_modules/@smithy/invalid-dependency": {
-			"version": "4.2.5",
-			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.5.tgz",
-			"integrity": "sha512-2L2erASEro1WC5nV+plwIMxrTXpvpfzl4e+Nre6vBVRR2HKeGGcvpJyyL3/PpiSg+cJG2KpTmZmq934Olb6e5A==",
+			"version": "4.2.14",
+			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.14.tgz",
+			"integrity": "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.9.0",
+				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -36285,9 +37043,9 @@
 			}
 		},
 		"node_modules/@smithy/is-array-buffer": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-			"integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+			"integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -36320,13 +37078,13 @@
 			}
 		},
 		"node_modules/@smithy/middleware-content-length": {
-			"version": "4.2.5",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.5.tgz",
-			"integrity": "sha512-Y/RabVa5vbl5FuHYV2vUCwvh/dqzrEY/K2yWPSqvhFUwIY0atLqO4TienjBXakoy4zrKAMCZwg+YEqmH7jaN7A==",
+			"version": "4.2.14",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz",
+			"integrity": "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/protocol-http": "^5.3.5",
-				"@smithy/types": "^4.9.0",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -36334,18 +37092,18 @@
 			}
 		},
 		"node_modules/@smithy/middleware-endpoint": {
-			"version": "4.3.12",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.12.tgz",
-			"integrity": "sha512-9pAX/H+VQPzNbouhDhkW723igBMLgrI8OtX+++M7iKJgg/zY/Ig3i1e6seCcx22FWhE6Q/S61BRdi2wXBORT+A==",
+			"version": "4.4.31",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.31.tgz",
+			"integrity": "sha512-KJPdCIN2kOE2aGmqZd7eUTr4WQwOGgtLWgUkswGJggs7rBcQYQjcZMEDa3C0DwbOiXS9L8/wDoQHkfxBYLfiLw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.18.5",
-				"@smithy/middleware-serde": "^4.2.6",
-				"@smithy/node-config-provider": "^4.3.5",
-				"@smithy/shared-ini-file-loader": "^4.4.0",
-				"@smithy/types": "^4.9.0",
-				"@smithy/url-parser": "^4.2.5",
-				"@smithy/util-middleware": "^4.2.5",
+				"@smithy/core": "^3.23.16",
+				"@smithy/middleware-serde": "^4.2.19",
+				"@smithy/node-config-provider": "^4.3.14",
+				"@smithy/shared-ini-file-loader": "^4.4.9",
+				"@smithy/types": "^4.14.1",
+				"@smithy/url-parser": "^4.2.14",
+				"@smithy/util-middleware": "^4.2.14",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -36353,19 +37111,20 @@
 			}
 		},
 		"node_modules/@smithy/middleware-retry": {
-			"version": "4.4.12",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.12.tgz",
-			"integrity": "sha512-S4kWNKFowYd0lID7/DBqWHOQxmxlsf0jBaos9chQZUWTVOjSW1Ogyh8/ib5tM+agFDJ/TCxuCTvrnlc+9cIBcQ==",
+			"version": "4.5.4",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.4.tgz",
+			"integrity": "sha512-/z7nIFK+ZRW3Ie/l3NEVGdy34LvmEOzBrtBAvgWZ/4PrKX0xP3kWm8pkfcwUk523SqxZhdbQP9JSXgjF77Uhpw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/node-config-provider": "^4.3.5",
-				"@smithy/protocol-http": "^5.3.5",
-				"@smithy/service-error-classification": "^4.2.5",
-				"@smithy/smithy-client": "^4.9.8",
-				"@smithy/types": "^4.9.0",
-				"@smithy/util-middleware": "^4.2.5",
-				"@smithy/util-retry": "^4.2.5",
-				"@smithy/uuid": "^1.1.0",
+				"@smithy/core": "^3.23.16",
+				"@smithy/node-config-provider": "^4.3.14",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/service-error-classification": "^4.3.0",
+				"@smithy/smithy-client": "^4.12.12",
+				"@smithy/types": "^4.14.1",
+				"@smithy/util-middleware": "^4.2.14",
+				"@smithy/util-retry": "^4.3.3",
+				"@smithy/uuid": "^1.1.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -36373,13 +37132,14 @@
 			}
 		},
 		"node_modules/@smithy/middleware-serde": {
-			"version": "4.2.6",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.6.tgz",
-			"integrity": "sha512-VkLoE/z7e2g8pirwisLz8XJWedUSY8my/qrp81VmAdyrhi94T+riBfwP+AOEEFR9rFTSonC/5D2eWNmFabHyGQ==",
+			"version": "4.2.19",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.19.tgz",
+			"integrity": "sha512-Q6y+W9h3iYVMCKWDoVge+OC1LKFqbEKaq8SIWG2X2bWJRpd/6dDLyICcNLT6PbjH3Rr6bmg/SeDB25XFOFfeEw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/protocol-http": "^5.3.5",
-				"@smithy/types": "^4.9.0",
+				"@smithy/core": "^3.23.16",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -36387,12 +37147,12 @@
 			}
 		},
 		"node_modules/@smithy/middleware-stack": {
-			"version": "4.2.5",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.5.tgz",
-			"integrity": "sha512-bYrutc+neOyWxtZdbB2USbQttZN0mXaOyYLIsaTbJhFsfpXyGWUxJpEuO1rJ8IIJm2qH4+xJT0mxUSsEDTYwdQ==",
+			"version": "4.2.14",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.14.tgz",
+			"integrity": "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.9.0",
+				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -36400,14 +37160,14 @@
 			}
 		},
 		"node_modules/@smithy/node-config-provider": {
-			"version": "4.3.5",
-			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.5.tgz",
-			"integrity": "sha512-UTurh1C4qkVCtqggI36DGbLB2Kv8UlcFdMXDcWMbqVY2uRg0XmT9Pb4Vj6oSQ34eizO1fvR0RnFV4Axw4IrrAg==",
+			"version": "4.3.14",
+			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.14.tgz",
+			"integrity": "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/property-provider": "^4.2.5",
-				"@smithy/shared-ini-file-loader": "^4.4.0",
-				"@smithy/types": "^4.9.0",
+				"@smithy/property-provider": "^4.2.14",
+				"@smithy/shared-ini-file-loader": "^4.4.9",
+				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -36415,15 +37175,14 @@
 			}
 		},
 		"node_modules/@smithy/node-http-handler": {
-			"version": "4.4.5",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.5.tgz",
-			"integrity": "sha512-CMnzM9R2WqlqXQGtIlsHMEZfXKJVTIrqCNoSd/QpAyp+Dw0a1Vps13l6ma1fH8g7zSPNsA59B/kWgeylFuA/lw==",
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.0.tgz",
+			"integrity": "sha512-P734cAoTFtuGfWa/R3jgBnGlURt2w9bYEBwQNMKf58sRM9RShirB2mKwLsVP+jlG/wxpCu8abv8NxdUts8tdLA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/abort-controller": "^4.2.5",
-				"@smithy/protocol-http": "^5.3.5",
-				"@smithy/querystring-builder": "^4.2.5",
-				"@smithy/types": "^4.9.0",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/querystring-builder": "^4.2.14",
+				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -36431,13 +37190,13 @@
 			}
 		},
 		"node_modules/@smithy/node-http-handler/node_modules/@smithy/querystring-builder": {
-			"version": "4.2.5",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.5.tgz",
-			"integrity": "sha512-y98otMI1saoajeik2kLfGyRp11e5U/iJYH/wLCh3aTV/XutbGT9nziKGkgCaMD1ghK7p6htHMm6b6scl9JRUWg==",
+			"version": "4.2.14",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
+			"integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.9.0",
-				"@smithy/util-uri-escape": "^4.2.0",
+				"@smithy/types": "^4.14.1",
+				"@smithy/util-uri-escape": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -36445,9 +37204,9 @@
 			}
 		},
 		"node_modules/@smithy/node-http-handler/node_modules/@smithy/util-uri-escape": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-			"integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+			"integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -36457,12 +37216,12 @@
 			}
 		},
 		"node_modules/@smithy/property-provider": {
-			"version": "4.2.5",
-			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.5.tgz",
-			"integrity": "sha512-8iLN1XSE1rl4MuxvQ+5OSk/Zb5El7NJZ1td6Tn+8dQQHIjp59Lwl6bd0+nzw6SKm2wSSriH2v/I9LPzUic7EOg==",
+			"version": "4.2.14",
+			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.14.tgz",
+			"integrity": "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.9.0",
+				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -36470,12 +37229,12 @@
 			}
 		},
 		"node_modules/@smithy/protocol-http": {
-			"version": "5.3.5",
-			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.5.tgz",
-			"integrity": "sha512-RlaL+sA0LNMp03bf7XPbFmT5gN+w3besXSWMkA8rcmxLSVfiEXElQi4O2IWwPfxzcHkxqrwBFMbngB8yx/RvaQ==",
+			"version": "5.3.14",
+			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+			"integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.9.0",
+				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -36509,12 +37268,12 @@
 			}
 		},
 		"node_modules/@smithy/querystring-parser": {
-			"version": "4.2.5",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.5.tgz",
-			"integrity": "sha512-031WCTdPYgiQRYNPXznHXof2YM0GwL6SeaSyTH/P72M1Vz73TvCNH2Nq8Iu2IEPq9QP2yx0/nrw5YmSeAi/AjQ==",
+			"version": "4.2.14",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.14.tgz",
+			"integrity": "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.9.0",
+				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -36522,24 +37281,24 @@
 			}
 		},
 		"node_modules/@smithy/service-error-classification": {
-			"version": "4.2.5",
-			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.5.tgz",
-			"integrity": "sha512-8fEvK+WPE3wUAcDvqDQG1Vk3ANLR8Px979te96m84CbKAjBVf25rPYSzb4xU4hlTyho7VhOGnh5i62D/JVF0JQ==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.0.tgz",
+			"integrity": "sha512-9jKsBYQRPR0xBLgc2415RsA5PIcP2sis4oBdN9s0D13cg1B1284mNTjx9Yc+BEERXzuPm5ObktI96OxsKh8E9A==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.9.0"
+				"@smithy/types": "^4.14.1"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/shared-ini-file-loader": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.0.tgz",
-			"integrity": "sha512-5WmZ5+kJgJDjwXXIzr1vDTG+RhF9wzSODQBfkrQ2VVkYALKGvZX1lgVSxEkgicSAFnFhPj5rudJV0zoinqS0bA==",
+			"version": "4.4.9",
+			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz",
+			"integrity": "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.9.0",
+				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -36547,18 +37306,18 @@
 			}
 		},
 		"node_modules/@smithy/signature-v4": {
-			"version": "5.3.5",
-			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.5.tgz",
-			"integrity": "sha512-xSUfMu1FT7ccfSXkoLl/QRQBi2rOvi3tiBZU2Tdy3I6cgvZ6SEi9QNey+lqps/sJRnogIS+lq+B1gxxbra2a/w==",
+			"version": "5.3.14",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
+			"integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/is-array-buffer": "^4.2.0",
-				"@smithy/protocol-http": "^5.3.5",
-				"@smithy/types": "^4.9.0",
-				"@smithy/util-hex-encoding": "^4.2.0",
-				"@smithy/util-middleware": "^4.2.5",
-				"@smithy/util-uri-escape": "^4.2.0",
-				"@smithy/util-utf8": "^4.2.0",
+				"@smithy/is-array-buffer": "^4.2.2",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/types": "^4.14.1",
+				"@smithy/util-hex-encoding": "^4.2.2",
+				"@smithy/util-middleware": "^4.2.14",
+				"@smithy/util-uri-escape": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -36566,9 +37325,9 @@
 			}
 		},
 		"node_modules/@smithy/signature-v4/node_modules/@smithy/util-hex-encoding": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
-			"integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+			"integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -36578,9 +37337,9 @@
 			}
 		},
 		"node_modules/@smithy/signature-v4/node_modules/@smithy/util-uri-escape": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-			"integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+			"integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -36590,12 +37349,12 @@
 			}
 		},
 		"node_modules/@smithy/signature-v4/node_modules/@smithy/util-utf8": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-			"integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+			"integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/util-buffer-from": "^4.2.0",
+				"@smithy/util-buffer-from": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -36603,17 +37362,17 @@
 			}
 		},
 		"node_modules/@smithy/smithy-client": {
-			"version": "4.9.8",
-			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.9.8.tgz",
-			"integrity": "sha512-8xgq3LgKDEFoIrLWBho/oYKyWByw9/corz7vuh1upv7ZBm0ZMjGYBhbn6v643WoIqA9UTcx5A5htEp/YatUwMA==",
+			"version": "4.12.12",
+			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.12.tgz",
+			"integrity": "sha512-daO7SJn4eM6ArbmrEs+/BTbH7af8AEbSL3OMQdcRvvn8tuUcR5rU2n6DgxIV53aXMS42uwK8NgKKCh5XgqYOPQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.18.5",
-				"@smithy/middleware-endpoint": "^4.3.12",
-				"@smithy/middleware-stack": "^4.2.5",
-				"@smithy/protocol-http": "^5.3.5",
-				"@smithy/types": "^4.9.0",
-				"@smithy/util-stream": "^4.5.6",
+				"@smithy/core": "^3.23.16",
+				"@smithy/middleware-endpoint": "^4.4.31",
+				"@smithy/middleware-stack": "^4.2.14",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/types": "^4.14.1",
+				"@smithy/util-stream": "^4.5.24",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -36621,9 +37380,9 @@
 			}
 		},
 		"node_modules/@smithy/types": {
-			"version": "4.9.0",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.9.0.tgz",
-			"integrity": "sha512-MvUbdnXDTwykR8cB1WZvNNwqoWVaTRA0RLlLmf/cIFNMM2cKWz01X4Ly6SMC4Kks30r8tT3Cty0jmeWfiuyHTA==",
+			"version": "4.14.1",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
+			"integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -36633,13 +37392,13 @@
 			}
 		},
 		"node_modules/@smithy/url-parser": {
-			"version": "4.2.5",
-			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.5.tgz",
-			"integrity": "sha512-VaxMGsilqFnK1CeBX+LXnSuaMx4sTL/6znSZh2829txWieazdVxr54HmiyTsIbpOTLcf5nYpq9lpzmwRdxj6rQ==",
+			"version": "4.2.14",
+			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.14.tgz",
+			"integrity": "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/querystring-parser": "^4.2.5",
-				"@smithy/types": "^4.9.0",
+				"@smithy/querystring-parser": "^4.2.14",
+				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -36699,9 +37458,9 @@
 			}
 		},
 		"node_modules/@smithy/util-body-length-browser": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
-			"integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+			"integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -36711,9 +37470,9 @@
 			}
 		},
 		"node_modules/@smithy/util-body-length-node": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
-			"integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+			"integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -36723,12 +37482,12 @@
 			}
 		},
 		"node_modules/@smithy/util-buffer-from": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-			"integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+			"integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/is-array-buffer": "^4.2.0",
+				"@smithy/is-array-buffer": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -36736,9 +37495,9 @@
 			}
 		},
 		"node_modules/@smithy/util-config-provider": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
-			"integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+			"integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -36748,14 +37507,14 @@
 			}
 		},
 		"node_modules/@smithy/util-defaults-mode-browser": {
-			"version": "4.3.11",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.11.tgz",
-			"integrity": "sha512-yHv+r6wSQXEXTPVCIQTNmXVWs7ekBTpMVErjqZoWkYN75HIFN5y9+/+sYOejfAuvxWGvgzgxbTHa/oz61YTbKw==",
+			"version": "4.3.48",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.48.tgz",
+			"integrity": "sha512-hxVRVPYaRDWa6YQdse1aWX1qrksmLsvNyGBKdc32q4jFzSjxYVNWfstknAfR228TnzS4tzgswXRuYIbhXBuXFQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/property-provider": "^4.2.5",
-				"@smithy/smithy-client": "^4.9.8",
-				"@smithy/types": "^4.9.0",
+				"@smithy/property-provider": "^4.2.14",
+				"@smithy/smithy-client": "^4.12.12",
+				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -36763,17 +37522,17 @@
 			}
 		},
 		"node_modules/@smithy/util-defaults-mode-node": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.14.tgz",
-			"integrity": "sha512-ljZN3iRvaJUgulfvobIuG97q1iUuCMrvXAlkZ4msY+ZuVHQHDIqn7FKZCEj+bx8omz6kF5yQXms/xhzjIO5XiA==",
+			"version": "4.2.53",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.53.tgz",
+			"integrity": "sha512-ybgCk+9JdBq8pYC8Y6U5fjyS8e4sboyAShetxPNL0rRBtaVl56GSFAxsolVBIea1tXR4LPIzL8i6xqmcf0+DCQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/config-resolver": "^4.4.3",
-				"@smithy/credential-provider-imds": "^4.2.5",
-				"@smithy/node-config-provider": "^4.3.5",
-				"@smithy/property-provider": "^4.2.5",
-				"@smithy/smithy-client": "^4.9.8",
-				"@smithy/types": "^4.9.0",
+				"@smithy/config-resolver": "^4.4.17",
+				"@smithy/credential-provider-imds": "^4.2.14",
+				"@smithy/node-config-provider": "^4.3.14",
+				"@smithy/property-provider": "^4.2.14",
+				"@smithy/smithy-client": "^4.12.12",
+				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -36781,13 +37540,13 @@
 			}
 		},
 		"node_modules/@smithy/util-endpoints": {
-			"version": "3.2.5",
-			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.5.tgz",
-			"integrity": "sha512-3O63AAWu2cSNQZp+ayl9I3NapW1p1rR5mlVHcF6hAB1dPZUQFfRPYtplWX/3xrzWthPGj5FqB12taJJCfH6s8A==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.2.tgz",
+			"integrity": "sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/node-config-provider": "^4.3.5",
-				"@smithy/types": "^4.9.0",
+				"@smithy/node-config-provider": "^4.3.14",
+				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -36807,12 +37566,12 @@
 			}
 		},
 		"node_modules/@smithy/util-middleware": {
-			"version": "4.2.5",
-			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.5.tgz",
-			"integrity": "sha512-6Y3+rvBF7+PZOc40ybeZMcGln6xJGVeY60E7jy9Mv5iKpMJpHgRE6dKy9ScsVxvfAYuEX4Q9a65DQX90KaQ3bA==",
+			"version": "4.2.14",
+			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.14.tgz",
+			"integrity": "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.9.0",
+				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -36820,13 +37579,13 @@
 			}
 		},
 		"node_modules/@smithy/util-retry": {
-			"version": "4.2.5",
-			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.5.tgz",
-			"integrity": "sha512-GBj3+EZBbN4NAqJ/7pAhsXdfzdlznOh8PydUijy6FpNIMnHPSMO2/rP4HKu+UFeikJxShERk528oy7GT79YiJg==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.3.tgz",
+			"integrity": "sha512-idjUvd4M9Jj6rXkhqw4H4reHoweuK4ZxYWyOrEp4N2rOF5VtaOlQGLDQJva/8WanNXk9ScQtsAb7o5UHGvFm4A==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/service-error-classification": "^4.2.5",
-				"@smithy/types": "^4.9.0",
+				"@smithy/service-error-classification": "^4.3.0",
+				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -36834,18 +37593,18 @@
 			}
 		},
 		"node_modules/@smithy/util-stream": {
-			"version": "4.5.6",
-			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.6.tgz",
-			"integrity": "sha512-qWw/UM59TiaFrPevefOZ8CNBKbYEP6wBAIlLqxn3VAIo9rgnTNc4ASbVrqDmhuwI87usnjhdQrxodzAGFFzbRQ==",
+			"version": "4.5.24",
+			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.24.tgz",
+			"integrity": "sha512-na5vv2mBSDzXewLEEoWGI7LQQkfpmFEomBsmOpzLFjqGctm0iMwXY5lAwesY9pIaErkccW0qzEOUcYP+WKneXg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/fetch-http-handler": "^5.3.6",
-				"@smithy/node-http-handler": "^4.4.5",
-				"@smithy/types": "^4.9.0",
-				"@smithy/util-base64": "^4.3.0",
-				"@smithy/util-buffer-from": "^4.2.0",
-				"@smithy/util-hex-encoding": "^4.2.0",
-				"@smithy/util-utf8": "^4.2.0",
+				"@smithy/fetch-http-handler": "^5.3.17",
+				"@smithy/node-http-handler": "^4.6.0",
+				"@smithy/types": "^4.14.1",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-buffer-from": "^4.2.2",
+				"@smithy/util-hex-encoding": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -36853,13 +37612,13 @@
 			}
 		},
 		"node_modules/@smithy/util-stream/node_modules/@smithy/util-base64": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
-			"integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+			"integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/util-buffer-from": "^4.2.0",
-				"@smithy/util-utf8": "^4.2.0",
+				"@smithy/util-buffer-from": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -36867,9 +37626,9 @@
 			}
 		},
 		"node_modules/@smithy/util-stream/node_modules/@smithy/util-hex-encoding": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
-			"integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+			"integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -36879,12 +37638,12 @@
 			}
 		},
 		"node_modules/@smithy/util-stream/node_modules/@smithy/util-utf8": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-			"integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+			"integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/util-buffer-from": "^4.2.0",
+				"@smithy/util-buffer-from": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -36942,13 +37701,12 @@
 			}
 		},
 		"node_modules/@smithy/util-waiter": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.3.tgz",
-			"integrity": "sha512-5+nU///E5sAdD7t3hs4uwvCTWQtTR8JwKwOCSJtBRx0bY1isDo1QwH87vRK86vlFLBTISqoDA2V6xvP6nF1isQ==",
+			"version": "4.2.16",
+			"resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.16.tgz",
+			"integrity": "sha512-GtclrKoZ3Lt7jPQ7aTIYKfjY92OgceScftVnkTsG8e1KV8rkvZgN+ny6YSRhd9hxB8rZtwVbmln7NTvE5O3GmQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/abort-controller": "^4.2.3",
-				"@smithy/types": "^4.8.0",
+				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -36956,9 +37714,9 @@
 			}
 		},
 		"node_modules/@smithy/uuid": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
-			"integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+			"integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -43076,6 +43834,21 @@
 			],
 			"license": "BSD-3-Clause"
 		},
+		"node_modules/fast-xml-builder": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+			"integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"path-expression-matcher": "^1.1.3"
+			}
+		},
 		"node_modules/fast-xml-parser": {
 			"version": "4.5.3",
 			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
@@ -48327,6 +49100,15 @@
 				"node": ">=16 || 14 >=14.17"
 			}
 		},
+		"node_modules/mnemonist": {
+			"version": "0.38.3",
+			"resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+			"integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+			"license": "MIT",
+			"dependencies": {
+				"obliterator": "^1.6.1"
+			}
+		},
 		"node_modules/module-definition": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/module-definition/-/module-definition-6.0.1.tgz",
@@ -48889,6 +49671,12 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/obliterator": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+			"integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
+			"license": "MIT"
+		},
 		"node_modules/on-finished": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -49313,6 +50101,21 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/path-expression-matcher": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+			"integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/path-is-absolute": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"@aws-amplify/cli": "^14.0.0",
 		"@aws-amplify/storage": "^6.9.4",
 		"@aws-amplify/ui-react": "^6.11.2",
+		"@aws-sdk/client-dynamodb": "^3.1034.0",
 		"@aws-sdk/client-kms": "^3.864.0",
 		"@aws-sdk/client-s3": "^3.864.0",
 		"@aws-sdk/client-sesv2": "^3.936.0",

--- a/shared/types/llmGrouping.ts
+++ b/shared/types/llmGrouping.ts
@@ -36,6 +36,8 @@ export type GroupingInput = {
  */
 export type GroupingLLMResponse = {
   groups: CategorizedGroup[];
+  /** True when the remote endpoint returned 429; groups contains the local fallback. */
+  rateLimited?: boolean;
 };
 
 /**

--- a/src/__tests__/backend/handlers/groupBookmarks.test.ts
+++ b/src/__tests__/backend/handlers/groupBookmarks.test.ts
@@ -1,0 +1,244 @@
+export {};
+
+// Must be hoisted before handler import so the module-level `new OpenAI()` gets the mock.
+jest.mock("openai", () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    responses: {
+      create: jest.fn().mockResolvedValue({
+        output_text: JSON.stringify({
+          groups: [
+            {
+              id: "grp-1",
+              name: "Technology",
+              description: "Tech sites",
+              purpose: "personal",
+              itemIds: ["item-1", "item-2", "item-3", "item-4"],
+            },
+          ],
+        }),
+      }),
+    },
+  })),
+}));
+
+import { mockClient } from "aws-sdk-client-mock";
+import { DynamoDBClient, UpdateItemCommand } from "@aws-sdk/client-dynamodb";
+import { handler } from "../../../../amplify/functions/groupBookmarks/handler";
+
+const dynamoMock = mockClient(DynamoDBClient);
+
+// ── Event builders ────────────────────────────────────────────────────────────
+
+const makeEvent = (body: unknown, ip = "1.2.3.4") => ({
+  httpMethod: "POST",
+  body: JSON.stringify(body),
+  isBase64Encoded: false,
+  headers: { origin: "http://localhost:5173" },
+  requestContext: { http: { sourceIp: ip, method: "POST" } },
+});
+
+// 2-item batch: handler short-circuits before calling OpenAI (≤3 items), so
+// these tests exercise only the rate-limit path, not the LLM path.
+const smallBatch = (ip = "1.2.3.4") =>
+  makeEvent(
+    {
+      items: [
+        { id: "item-1", title: "Example", url: "https://example.com" },
+        { id: "item-2", title: "Test", url: "https://test.com" },
+      ],
+      purposes: ["personal"],
+    },
+    ip
+  );
+
+// 4-item batch: reaches the OpenAI call (mocked above).
+const largeBatch = (ip = "1.2.3.4") =>
+  makeEvent(
+    {
+      items: [
+        { id: "item-1", title: "GitHub", url: "https://github.com" },
+        { id: "item-2", title: "MDN", url: "https://developer.mozilla.org" },
+        { id: "item-3", title: "Stack Overflow", url: "https://stackoverflow.com" },
+        { id: "item-4", title: "TypeScript", url: "https://typescriptlang.org" },
+      ],
+      purposes: ["personal"],
+    },
+    ip
+  );
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Set up DynamoDB mock to report `count` calls for the current window. */
+const mockCount = (count: number) =>
+  dynamoMock
+    .on(UpdateItemCommand)
+    .resolves({ Attributes: { n: { N: String(count) } } });
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("groupBookmarks handler", () => {
+  beforeEach(() => {
+    dynamoMock.reset();
+  });
+
+  // ── Rate limiting ────────────────────────────────────────────────────────────
+
+  describe("rate limiting", () => {
+    test("allows requests when count is 1 (well under limit)", async () => {
+      mockCount(1);
+      const res = await handler(smallBatch());
+      expect(res.statusCode).toBe(200);
+    });
+
+    test("allows requests when count equals RATE_LIMIT_MAX (boundary: check is >5, not >=5)", async () => {
+      mockCount(5);
+      const res = await handler(smallBatch());
+      expect(res.statusCode).toBe(200);
+    });
+
+    test("blocks the request when count exceeds RATE_LIMIT_MAX", async () => {
+      mockCount(6);
+      const res = await handler(smallBatch());
+      expect(res.statusCode).toBe(429);
+      expect(JSON.parse(res.body).message).toMatch(/rate limit/i);
+    });
+
+    test("different IPs are rate-limited independently", async () => {
+      // First call (IP A) is over limit; second call (IP B) is its first request.
+      dynamoMock
+        .on(UpdateItemCommand)
+        .resolvesOnce({ Attributes: { n: { N: "6" } } })
+        .resolvesOnce({ Attributes: { n: { N: "1" } } });
+
+      const resA = await handler(smallBatch("10.0.0.1"));
+      const resB = await handler(smallBatch("10.0.0.2"));
+
+      expect(resA.statusCode).toBe(429);
+      expect(resB.statusCode).toBe(200);
+    });
+
+    test("rate-limit key encodes the caller IP", async () => {
+      mockCount(1);
+      await handler(smallBatch("192.168.1.100"));
+
+      const calls = dynamoMock.commandCalls(UpdateItemCommand);
+      const pk = (calls[0] as any).args[0].input.Key?.pk?.S as string;
+      expect(pk).toContain("192.168.1.100");
+    });
+
+    test("rate-limit key changes when the time window rolls over", async () => {
+      jest.useFakeTimers();
+      const RATE_WINDOW_SEC = 600;
+      mockCount(1);
+
+      jest.setSystemTime(new Date(0));
+      await handler(smallBatch());
+
+      // Advance into the next window.
+      jest.setSystemTime(new Date((RATE_WINDOW_SEC + 1) * 1000));
+      await handler(smallBatch());
+
+      const calls = dynamoMock.commandCalls(UpdateItemCommand);
+      const pk0 = (calls[0] as any).args[0].input.Key?.pk?.S as string;
+      const pk1 = (calls[1] as any).args[0].input.Key?.pk?.S as string;
+
+      expect(pk0).not.toBe(pk1);
+
+      jest.useRealTimers();
+    });
+
+    test("rate-limit TTL is set to the end of the current window", async () => {
+      jest.useFakeTimers();
+      const RATE_WINDOW_SEC = 600;
+      jest.setSystemTime(new Date(300_000)); // t = 300 s (middle of window 0)
+      mockCount(1);
+
+      await handler(smallBatch());
+
+      const calls = dynamoMock.commandCalls(UpdateItemCommand);
+      const input = (calls[0] as any).args[0].input;
+      const ttl = Number(input.ExpressionAttributeValues?.[":exp"]?.N);
+
+      // Window 0 ends at 600 s.
+      expect(ttl).toBe(RATE_WINDOW_SEC);
+
+      jest.useRealTimers();
+    });
+
+    test("OPTIONS preflight is returned before the rate-limit check (DynamoDB not called)", async () => {
+      const res = await handler({
+        httpMethod: "OPTIONS",
+        headers: { origin: "http://localhost:5173" },
+        requestContext: { http: { sourceIp: "1.2.3.4", method: "OPTIONS" } },
+      });
+
+      expect(res.statusCode).toBe(204);
+      expect(dynamoMock.commandCalls(UpdateItemCommand)).toHaveLength(0);
+    });
+  });
+
+  // ── Input validation ─────────────────────────────────────────────────────────
+
+  describe("input validation", () => {
+    beforeEach(() => mockCount(1));
+
+    test("returns 400 when body is absent", async () => {
+      const res = await handler({
+        httpMethod: "POST",
+        headers: { origin: "http://localhost:5173" },
+        requestContext: { http: { sourceIp: "1.2.3.4", method: "POST" } },
+      });
+      expect(res.statusCode).toBe(400);
+    });
+
+    test("returns 400 when items[] is missing from the body", async () => {
+      const res = await handler(
+        makeEvent({ purposes: ["personal"] })
+      );
+      expect(res.statusCode).toBe(400);
+    });
+
+    test("returns 400 when purposes[] is missing from the body", async () => {
+      const res = await handler(
+        makeEvent({ items: [{ id: "1", url: "https://example.com" }] })
+      );
+      expect(res.statusCode).toBe(400);
+    });
+
+    test("returns 400 when purposes[] is present but contains no valid values", async () => {
+      const res = await handler(
+        makeEvent({
+          items: [{ id: "1", url: "https://example.com" }],
+          purposes: ["unknown-purpose"],
+        })
+      );
+      expect(res.statusCode).toBe(400);
+    });
+  });
+
+  // ── Normal operation ─────────────────────────────────────────────────────────
+
+  describe("normal operation", () => {
+    beforeEach(() => mockCount(1));
+
+    test("returns 200 with grouped results for a small import (≤3 items, no OpenAI call)", async () => {
+      const res = await handler(smallBatch());
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(Array.isArray(body.groups)).toBe(true);
+      expect(body.groups.length).toBeGreaterThan(0);
+      // All submitted items must appear somewhere in the groups
+      const coveredIds = body.groups.flatMap((g: any) => g.items.map((i: any) => i.id));
+      expect(coveredIds).toContain("item-1");
+      expect(coveredIds).toContain("item-2");
+    });
+
+    test("returns 200 with grouped results for a larger import (calls mocked OpenAI)", async () => {
+      const res = await handler(largeBatch());
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(Array.isArray(body.groups)).toBe(true);
+    });
+  });
+});

--- a/src/__tests__/backend/handlers/groupBookmarks.test.ts
+++ b/src/__tests__/backend/handlers/groupBookmarks.test.ts
@@ -91,14 +91,14 @@ describe("groupBookmarks handler", () => {
       expect(res.statusCode).toBe(200);
     });
 
-    test("allows requests when count equals RATE_LIMIT_MAX (boundary: check is >5, not >=5)", async () => {
-      mockCount(5);
+    test("allows requests when count equals RATE_LIMIT_MAX (boundary: check is >10, not >=10)", async () => {
+      mockCount(10);
       const res = await handler(smallBatch());
       expect(res.statusCode).toBe(200);
     });
 
     test("blocks the request when count exceeds RATE_LIMIT_MAX", async () => {
-      mockCount(6);
+      mockCount(11);
       const res = await handler(smallBatch());
       expect(res.statusCode).toBe(429);
       expect(JSON.parse(res.body).message).toMatch(/rate limit/i);
@@ -108,7 +108,7 @@ describe("groupBookmarks handler", () => {
       // First call (IP A) is over limit; second call (IP B) is its first request.
       dynamoMock
         .on(UpdateItemCommand)
-        .resolvesOnce({ Attributes: { n: { N: "6" } } })
+        .resolvesOnce({ Attributes: { n: { N: "11" } } })
         .resolvesOnce({ Attributes: { n: { N: "1" } } });
 
       const resA = await handler(smallBatch("10.0.0.1"));

--- a/src/__tests__/backend/jest.setup.cjs
+++ b/src/__tests__/backend/jest.setup.cjs
@@ -2,6 +2,8 @@ process.env.S3_BUCKET_NAME = 'test-bucket';
 process.env.KMS_KEY_ID = 'alias/test-kms';
 process.env.BOOKMARKS_FILE_NAME = 'bookmarks.json';
 process.env.KEY_FILE_NAME = 'key.bin'; // remove later once fully off V1
+process.env.OPENAI_API_KEY = 'test-openai-key';
+process.env.RATE_LIMIT_TABLE = 'test-rate-limit-table';
 
 global.chrome = {
   runtime: {

--- a/src/__tests__/components/shared/ImportProgress.test.tsx
+++ b/src/__tests__/components/shared/ImportProgress.test.tsx
@@ -96,7 +96,7 @@ describe("useSmoothedPhase", () => {
     expect(result!.visualPhase).toBe("categorizing");
   });
 
-  it("does not regress if backendPhase goes backwards", () => {
+  it("resets immediately when backendPhase goes backwards (e.g. new organize run)", () => {
     let result: ReturnType<typeof useSmoothedPhase> | null = null;
 
     function Test({ backendPhase }: { backendPhase: Phase }) {
@@ -106,19 +106,22 @@ describe("useSmoothedPhase", () => {
 
     const { rerender } = render(<Test backendPhase="categorizing" />);
 
-    // Step to organizing (index 2) *in increments*
+    // Step to index 2 (categorizing) in increments
     tickPhaseOnce();
     expect(result!.visualPhase).toBe("importing");
 
     tickPhaseOnce();
     expect(result!.visualPhase).toBe("categorizing");
 
-    // Backend regresses
+    // Backend resets to start of a new run
     rerender(<Test backendPhase="initializing" />);
 
-    // Ensure no regression occurs
+    // Visual phase resets immediately to match backendPhase
+    expect(result!.visualPhase).toBe("initializing");
+
+    // A tick with backend already at index 0 does not advance
     tickPhaseOnce();
-    expect(result!.visualPhase).toBe("categorizing");
+    expect(result!.visualPhase).toBe("initializing");
   });
 });
 

--- a/src/__tests__/scripts/import/groupingLLMRemote.test.ts
+++ b/src/__tests__/scripts/import/groupingLLMRemote.test.ts
@@ -189,5 +189,35 @@ describe("remoteGroupingLLM.group", () => {
     });
 
     expect(consoleErrorSpy).toHaveBeenCalled();
+    expect(result.rateLimited).toBeFalsy();
+  });
+
+  it("returns rateLimited: true and the fallback group when the API responds with 429", async () => {
+    const items = makeItems(10);
+    const input: GroupingInput = {
+      items,
+      purposes: [PurposeId.Personal],
+    };
+
+    jest.spyOn(console, "error").mockImplementation(() => {});
+
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 429,
+      text: async () => "Too Many Requests",
+    });
+
+    const result = await remoteGroupingLLM.group(input);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result.rateLimited).toBe(true);
+    expect(result.groups).toHaveLength(1);
+    expect(result.groups[0]).toEqual({
+      id: "imported",
+      name: "Imported",
+      description: "All imported items",
+      purpose: PurposeId.Personal,
+      items,
+    });
   });
 });

--- a/src/components/shared/ImportProgress.tsx
+++ b/src/components/shared/ImportProgress.tsx
@@ -46,7 +46,14 @@ export function useSmoothedPhase(
   useEffect(() => {
     const backendIndex = phaseSequence.indexOf(backendPhase);
     if (backendIndex === -1) return;
-    if (backendIndex <= visualPhaseIndex) return;
+
+    // Backend moved backward (new run started) — reset immediately
+    if (backendIndex < visualPhaseIndex) {
+      setVisualPhaseIndex(backendIndex);
+      return;
+    }
+
+    if (backendIndex === visualPhaseIndex) return;
 
     const t = setTimeout(() => {
       setVisualPhaseIndex((prev) => Math.min(prev + 1, backendIndex));

--- a/src/pages/NewTabPage.tsx
+++ b/src/pages/NewTabPage.tsx
@@ -150,7 +150,7 @@ export function NewTabPage({ user, signIn, signOut }: NewTabPageProps): ReactEle
   const organizeRunRef = useRef(0);
   const pendingCopyRef = useRef<CopyPayload | null>(null);
   const [toastMsg, setToastMsg] = useState<string | null>(null);
-  const toast = (msg: string) => setToastMsg(msg);
+  const toast = (msg: string) => { setToastMsg(null); setTimeout(() => setToastMsg(msg), 0); };
 
   // File drag-and-drop state
   const [isDragActive, setIsDragActive] = useState(false);
@@ -372,6 +372,7 @@ export function NewTabPage({ user, signIn, signOut }: NewTabPageProps): ReactEle
     const isStale = () => organizeRunRef.current !== runId;
 
     setOrganizePhase('initializing');
+    setOrganizeSucceeded(false);
     setIsOrganizing(true);
     try {
       // Phase: categorizing — API call is now in flight

--- a/src/pages/NewTabPage.tsx
+++ b/src/pages/NewTabPage.tsx
@@ -379,6 +379,11 @@ export function NewTabPage({ user, signIn, signOut }: NewTabPageProps): ReactEle
       const result = await remoteGroupingLLM.group({ items: rawItems, purposes: purposes as any });
       if (isStale()) return; // Undo clicked before data was written — just bail
 
+      if (result.rateLimited) {
+        toast("AI Organize limit reached — please wait a few minutes before trying again.");
+        return; // finally block resets isOrganizing + phase
+      }
+
       // Phase: persisting — write new groups to storage
       setOrganizePhase('persisting');
       const emptyGroup = bookmarkGroupsRaw.find(g => g.groupName === EMPTY_GROUP_IDENTIFIER);

--- a/src/scripts/import/groupingLLMRemote.ts
+++ b/src/scripts/import/groupingLLMRemote.ts
@@ -88,6 +88,7 @@ export const remoteGroupingLLM: GroupingLLM = {
     });
 
     if (!res.ok) {
+      const isRateLimited = res.status === 429;
       console.error("remoteGroupingLLM error", res.status, await res.text());
 
       const fallbackGroup: CategorizedGroup = {
@@ -98,7 +99,7 @@ export const remoteGroupingLLM: GroupingLLM = {
         items: input.items,
       };
 
-      return { groups: [fallbackGroup] };
+      return { groups: [fallbackGroup], rateLimited: isRateLimited };
     }
 
     const data = (await res.json()) as GroupingLLMResponse;

--- a/test_group_bookmarks.sh
+++ b/test_group_bookmarks.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-URL="https://eidotpc2fc.execute-api.us-west-1.amazonaws.com/groupBookmarks"
-BODY='{"items":[{"id":"1","url":"https://example.com","title":"Test"}],"purposes":["personal"]}'
-
-for i in $(seq 1 12); do
-  curl -s -o /dev/null -w "Call $i: %{http_code}\n" -X POST "$URL" -H "Content-Type: application/json" -d "$BODY"
-done

--- a/test_group_bookmarks.sh
+++ b/test_group_bookmarks.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+URL="https://eidotpc2fc.execute-api.us-west-1.amazonaws.com/groupBookmarks"
+BODY='{"items":[{"id":"1","url":"https://example.com","title":"Test"}],"purposes":["personal"]}'
+
+for i in $(seq 1 12); do
+  curl -s -o /dev/null -w "Call $i: %{http_code}\n" -X POST "$URL" -H "Content-Type: application/json" -d "$BODY"
+done


### PR DESCRIPTION
## Summary

- **API Gateway throttling**: stage-level burst (30) + rate (10 req/s) limits guard against flood traffic across all callers
- **Per-IP rate limiting**: DynamoDB tracks calls per IP per 10-minute window; blocks at >10 calls with a 429 response
- **Frontend 429 handling**: `remoteGroupingLLM` sets `rateLimited: true` on a 429 response; `organizeWorkspace` in `NewTabPage` shows a user-facing toast and bails out without reorganizing the workspace
- **CORS fix for error responses**: `safe.ts` now reuses the request-scoped `Allow-Origin` header in the catch block, fixing "Failed to fetch" when a 429 is returned from a non-production origin
- **Progress bar reset on re-organize**: `useSmoothedPhase` now resets `visualPhaseIndex` when `backendPhase` moves backward, so the bar starts from 0 on a second organize run instead of showing "all completed"
- **Toast re-trigger fix**: toast helper clears to `null` before setting the new message so repeated identical toasts always trigger a re-render
- **organizeSucceeded reset**: `setOrganizeSucceeded(false)` is now called at the top of each `organizeWorkspace` run to prevent the success card from flashing on a re-run

## Changed files

| File | What changed |
|---|---|
| `amplify/backend.ts` | DynamoDB rate-limit table + API Gateway stage throttle; table now created in `groupBookmarksFn.stack` so the env var resolves correctly |
| `amplify/functions/groupBookmarks/handler.ts` | Per-IP DynamoDB counter check before processing |
| `amplify/functions/_shared/safe.ts` | Hoist `cors` outside try block so 429/500 error responses carry the correct `Allow-Origin` |
| `shared/types/llmGrouping.ts` | Added `rateLimited?: boolean` to `GroupingLLMResponse` |
| `src/pages/NewTabPage.tsx` | Checks `rateLimited` flag; shows toast and exits; resets `organizeSucceeded` on new run; toast deduplication fix |
| `src/components/shared/ImportProgress.tsx` | Reset `visualPhaseIndex` when backend phase moves backward |
| `src/__tests__/backend/handlers/groupBookmarks.test.ts` | 14 tests for rate limiting, input validation, and normal operation |
| `src/__tests__/backend/jest.setup.cjs` | Jest setup for backend tests |
| `src/__tests__/scripts/import/groupingLLMRemote.test.ts` | Tests for 429 → `rateLimited: true` and non-429 → flag absent |

## Test plan

- [x] Run `npx jest src/__tests__/backend/handlers/groupBookmarks.test.ts` — all rate-limit and validation tests pass
- [x] Run `npx jest src/__tests__/scripts/import/groupingLLMRemote.test.ts` — all 7 tests pass including 429 path
- [x] Deploy sandbox (`npx ampx sandbox`), run `./test_group_bookmarks.sh` — calls 1–10 → 200, calls 11–12 → 429
- [x] In the extension, click AI Organize after hitting the limit — toast appears, workspace is not reorganized
- [x] Click AI Organize twice in a row (without refresh) — progress bar resets to 0 on second run; no spurious "All organized!" flash
- [x] Trigger the same toast message twice (e.g. hit rate limit twice) — toast appears both times

🤖 Generated with [Claude Code](https://claude.com/claude-code)